### PR TITLE
Add relocation `R_RISCV_RELAX_NORVC` for linker relaxation.

### DIFF
--- a/riscv-elf.md
+++ b/riscv-elf.md
@@ -445,7 +445,8 @@ Enum | ELF Reloc Type       | Description                     | Details
 55   | R_RISCV_SET16        | Local label subtraction         |
 56   | R_RISCV_SET32        | Local label subtraction         |
 57   | R_RISCV_32_PCREL     | PC-relative reference           | word32 = S + A - PC
-58-191  | *Reserved*        | Reserved for future standard use |
+58   | R_RISCV_RELAX_NORVC  | Instruction pair can be relaxed, but without the use of compressed instructions |
+59-191  | *Reserved*        | Reserved for future standard use |
 192-255 | *Reserved*        | Reserved for nonstandard ABI extensions |
 
 Nonstandard extensions are free to use relocation numbers 192-255 for any
@@ -575,14 +576,14 @@ The pseudoinstruction:
 expands to the following assembly and relocation:
 
 ```
-    auipc ra, 0           # R_RISCV_CALL (symbol), R_RISCV_RELAX (symbol)
+    auipc ra, 0           # R_RISCV_CALL (symbol), R_RISCV_RELAX
     jalr  ra, ra, 0
 ```
 
 and when `-fpic` is enabled it expands to:
 
 ```
-    auipc ra, 0           # R_RISCV_CALL_PLT (symbol), R_RISCV_RELAX (symbol)
+    auipc ra, 0           # R_RISCV_CALL_PLT (symbol), R_RISCV_RELAX
     jalr  ra, ra, 0
 ```
 
@@ -645,6 +646,75 @@ label:
    add t2, t2, t1
    sw t2, t0, %pcrel_lo(label)   # R_RISCV_PCREL_LO12_S (label)
 ```
+
+
+### R_RISCV_RELAX and R_RISCV_RELAX_NORVC
+
+A sequence with instructions marked by `R_RISCV_RELAX` indicates that the
+linker can relax them to a shorter one, including by using compressed
+instructions.  `R_RISCV_RELAX_NORVC` is same as `R_RISCV_RELAX`, except that
+compressed instructions cannot be used, only uncompressed ones.
+
+Example assembler shows how these two relocations work:
+
+```
+   .option rvc              # Enable C extension
+
+   call  symbol1
+
+   lui   a0,%hi(symbol2)
+   addi  a0,a0,%lo(symbol2)
+
+   .option norvc            # Disable C extension
+
+   call  symbol1
+
+   lui   a0,%hi(symbol2)
+   addi  a0,a0,%lo(symbol2)
+```
+
+expands to the following assembly and relocation:
+
+```
+   auipc ra, 0              # R_RISCV_CALL (symbol1), R_RISCV_RELAX
+   jalr  ra, ra, 0
+
+   lui   a0,%hi(symbol2)    # R_RISCV_HI20 (symbol2), R_RISCV_RELAX
+   addi  a0,a0,%lo(symbol2) # R_RISCV_LO12 (symbol2), R_RISCV_RELAX
+
+   auipc ra, 0              # R_RISCV_CALL (symbol1), R_RISCV_RELAX_NORVC
+   jalr  ra, ra, 0
+
+   lui   a0,%hi(symbol2)    # R_RISCV_HI20 (symbol2), R_RISCV_RELAX_NORVC
+   addi  a0,a0,%lo(symbol2) # R_RISCV_LO12 (symbol2), R_RISCV_RELAX_NORVC
+```
+
+and then the linker may relax them to the following code:
+
+```
+   c.j/c.jal symbol1           # `c.j` exists on RV32 and RV64, but `c.jal`
+                                 is RV32-only.
+or
+   jal/jalr symbol1            # If the immediate of compressed instructions
+                                 can not cover the symbol1, then try this
+
+   addi a0, gp, (symbol2 - gp) # Do this first if symbol2 is in range of gp
+or
+   c.lui a0 %hi(symbol2)       # If symbol2 isn't in range of gp, then try
+   addi a0, a0, %lo(symbol2)     to relax the `lui` to `c.lui`
+
+   jal/jalr symbol1            # R_RISCV_RELAX_NORVC is paired with `call`,
+                                 the `c.j` and `c.jal` are not allowed
+
+   addi a0, gp, (symbol2 - gp) # R_RISCV_RELAX_NORVC are paired with `lui`
+                                 and `addi`, the `c.lui` is not allowed
+```
+
+The first `call` may be relaxed to a compressed `jal` or `j`, and the second
+`lui and addi` pattern may be relaxed to the `c.lui and addi` pattern by the
+linker if possible, but the third and fourth one can only be relaxed to a 4-byte
+`jal`/`jalr` and `addi with gp relative address` since the `.option norvc`
+directive is set.
 
 
 ## <a name=thread-local-storage></a>Thread Local Storage


### PR DESCRIPTION
Dear all,

According to this discussion:
https://github.com/riscv/riscv-gnu-toolchain/issues/445

I think this can be divided into two different problems:
1. Current linker may relax instruction sequence to the compressed one for the norvc code.
2. Alignment issue when both rvc and norvc code present.

For now, GNU ld checks the ELF e_flag of each input object, and then decide whether or not to do the rvc relaxations.  Consider the following case:

.option rvc # Enable rvc
call Label # The first call
...
.option norvc # Disable rvc
call Label # The second call
...

The ELF e_flag's EF_RISCV_RVC of the object file is set to true if the rvc is enabled somewhere, even if we disable the rvc in another place.  Therefore, linker will convert the two `call` to 2-byte compressed `jal`, but the second `c.jal` isn't allowed since the `.option norvc` is set.  Checking the ELF e_flag is a file level (or object level) method, so we need another checking method to solve the first problem when both rvc and norvc code present in the same object.

Add a new relocation `R_RISCV_RELAX_NORVC` seemed the only solution.  The instruction sequence paired with `R_RISCV_RELAX` indicating that linker can relax this sequence to the shorter one, including the compressed instruction.  The `R_RISCV_RELAX_NORVC` is same as `R_RISCV_RELAX` except that the sequence can't be relaxed to the compressed instruction.

Even if the first problem is resolved, there still have some cases cause the second alignment problem, so I think that is another issue.  This change of elf-psabi try to solve the first problem, not the second one :)

Thanks
Best Regards
Nelson