### PR TITLE
Calling conventions for the lazily bound functions.

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -44,6 +44,20 @@ NOTE: This is not yet a requirement as existing toolchains predating this part
 of the specification do not adhere to this, and without improvements to linker
 relaxation support doing so would regress performance and code size.
 
+== Dynamic Linking
+
+Run-time linkers that use lazy binding must preserve all argument registers
+used in the standard calling convention for the ABI in use. Any functions that
+use additional argument registers must be annotated with
+`STO_RISCV_VARIANT_CC`, as defined in <<Symbol Table>>.
+
+NOTE: Vector registers have a variable size depending on the hardware
+implementation and can be quite large. Saving/restoring all these vector
+arguments in a run-time linker's lazy resolver would use a large amount of
+stack space and hurt performance. This attribute allows vector registers to
+not be part of the standard calling convention so run-time linkers are not
+required to save/restore them and can instead eagerly bind such functions.
+
 == C++ Name Mangling
 
 {Cpp} name mangling for RISC-V follows the
@@ -134,7 +148,22 @@ There are no RISC-V specific definitions relating to ELF string tables.
 
 === Symbol Table
 
-There are no RISC-V specific definitions relating to ELF symbol tables.
+st_other:: The lower 2 bits are used to specify a symbol's visibility. The
+remaining 6 bits have no defined meaning in the ELF gABI. We use the highest
+bit to mark functions that do not follow the standard calling convention for
+the ABI in use.
++
+The defined processor-specific `st_other` flags are listed in the following
+table.
++
+[%autowidth]
+|===
+| Name                 | Mask
+
+| STO_RISCV_VARIANT_CC | 0x80
+|===
++
+See <<Dynamic Linking>> for the meaning of `STO_RISCV_VARIANT_CC`.
 
 === Relocations
 
@@ -682,9 +711,21 @@ table.
 
 There are no RISC-V specific definitions relating to ELF note sections.
 
-=== Dynamic Table
+=== Dynamic Section
 
-There are no RISC-V specific definitions relating to dynamic tables.
+The defined processor-specific dynamic array tags are listed in the following
+table.
+
+[%autowidth]
+|===
+| Name                | Value      | d_un  | Executable        | Shared Object
+
+| DT_RISCV_VARIANT_CC | 0x70000001 | d_val | Platform specific | Platform specific
+|===
+
+An object must have the dynamic tag `DT_RISCV_VARIANT_CC` if it has one or more
+`R_RISCV_JUMP_SLOT` relocations against symbols with the `STO_RISCV_VARIANT_CC`
+attribute.
 
 === Hash Table
 


### PR DESCRIPTION
Currently, we save/restore a0-a7 and fa0-fa7 in glibc implementation to
avoid ruining the arguments of the resolving functions. In order to
define the vector calling convention, we need to specify the behavior of
the resolver in the dynamic linker. Vector registers may have a large
size and save/restore vector argument registers may occupy a large
portion of stack space during runtime resolving. It is unreasonable
large to save/restore all these vector argument registers in the
resolver.

In this patch, we define a special symbol attribute to avoid going
through the resolver for the special purpose, i.e., non-standard calling
convention or vector calling convention. We also define an additional
dynamic tag to indicate there are symbols with the special attribute in
the dynamic symbol table of the object.