### PR TITLE
New attribute: Tag_RISCV_reserved_register

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -896,6 +896,7 @@ value if the tag number is even.
 | Tag_RISCV_priv_spec                 |        8 | uleb128        | Indicates the major version of the privileged specification.
 | Tag_RISCV_priv_spec_minor           |       10 | uleb128        | Indicates the minor version of the privileged specification.
 | Tag_RISCV_priv_spec_revision        |       12 | uleb128        | Indicates the revision version of the privileged specification.
+| Tag_RISCV_reserved_register         |       14 | uleb128        | Indicates the extra reserved register information.
 | Reserved for non-standard attribute | >= 32768 | -              | -
 |===
 
@@ -941,6 +942,23 @@ file. Its values are defined as follows:
 Tag_RISCV_priv_spec contains the major/minor/revision version information of
 the privileged specification. It will report errors if object files of different
 privileged specification versions are merged.
+
+===== Tag_RISCV_reserved_register, 14, uleb128=register bit-vector
+
+Tag_RISCV_reserved_register contains the information about the reserved
+registers which are not reserved by ABI, it might reserved by specific
+compiler option like `-ffixed-x4` or special purpose ABI variant like
+overlay ABI.
+
+Format of Tag_RISCV_reserved_register is a bit-vector, each bit corresponding to
+a register, the bit order is same as dwarf register number.
+First bit is must set, used to distinguish between attribute is unset or having
+empty reserved register set.
+
+It will report errors if link object files with different
+Tag_RISCV_reserved_register values, but allowed link with object with and
+without Tag_RISCV_reserved_register value, the final value will take from the
+object which has set Tag_RISCV_reserved_register.
 
 == Code relaxation
 

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -896,7 +896,7 @@ value if the tag number is even.
 | Tag_RISCV_priv_spec                 |        8 | uleb128        | Indicates the major version of the privileged specification.
 | Tag_RISCV_priv_spec_minor           |       10 | uleb128        | Indicates the minor version of the privileged specification.
 | Tag_RISCV_priv_spec_revision        |       12 | uleb128        | Indicates the revision version of the privileged specification.
-| Tag_RISCV_reserved_register         |       14 | uleb128        | Indicates the extra reserved register information.
+| Tag_RISCV_reserved_registers        |       14 | uleb128        | Indicates the extra reserved register information.
 | Reserved for non-standard attribute | >= 32768 | -              | -
 |===
 
@@ -943,22 +943,23 @@ Tag_RISCV_priv_spec contains the major/minor/revision version information of
 the privileged specification. It will report errors if object files of different
 privileged specification versions are merged.
 
-===== Tag_RISCV_reserved_register, 14, uleb128=register bit-vector
+===== Tag_RISCV_reserved_registers, 14, uleb128=register bit-vector
 
-Tag_RISCV_reserved_register contains the information about the reserved
-registers which are not reserved by ABI, it might reserved by specific
-compiler option like `-ffixed-x4` or special purpose ABI variant like
+Tag_RISCV_reserved_registers contains the information about the reserved
+registers which are not reserved by ABI. Registers might be reserved by specific
+compiler option like `-ffixed-x4` or a special purpose ABI variant like
 overlay ABI.
 
-Format of Tag_RISCV_reserved_register is a bit-vector, each bit corresponding to
-a register, the bit order is same as dwarf register number.
+The encoding of Tag_RISCV_reserved_registers is a bit-vector, each bit
+corresponding to a register. The bit number for a register is the same as DWARF
+register numbers.
+
 First bit is must set, used to distinguish between attribute is unset or having
 empty reserved register set.
 
-It will report errors if link object files with different
-Tag_RISCV_reserved_register values, but allowed link with object with and
-without Tag_RISCV_reserved_register value, the final value will take from the
-object which has set Tag_RISCV_reserved_register.
+It will report errors if object files are linked with different
+Tag_RISCV_reserved_registers values, or if the tag is missing from any object
+when the tag is set in at least one linked object.
 
 == Code relaxation
 


### PR DESCRIPTION
## Motivation
Tag_RISCV_reserved_register used for record reserved register information,
desiged for resolve checking compatibility between ABI subvariants like
overlay ABI.

## Meaning
This attribute is a bit-vector of reserved register, but it can also
representation as a register list, syntax below:

```
RESERVED_REGS := '{' REG_LIST '}'

REG_LIST      := REG_LIST ',' REG_LIST
               | REG_RANGE
               | REG

REG_RANGE     := REG '-' REG

REG           := <register-name> | <abi-register-name> # e.g. x10, t3, f10 or fa2
```

For example: `x6`, `x7`, `x8` and `f10` are reserved, then the value of
Tag_RISCV_reserved_register is `0x400000001c1`, and it also could be represent
as `{x6, x7, x8, f10}` or `{x6-x8, f10}`.

## Merge Rule
It will report errors if link object files with different
Tag_RISCV_reserved_register values, but allowed link with object with and
without Tag_RISCV_reserved_register value, the final value will take from the
object which has set Tag_RISCV_reserved_register.