### PR TITLE
Tweak table layout

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -8,20 +8,20 @@ endif::[]
 
 === Integer Register Convention
 
-[%autowidth]
+[cols="1,1,2,2"]
 |===
-| Name    | ABI Mnemonic | Meaning                | Preserved across calls?
+| Name      | ABI Mnemonic | Meaning                | Preserved across calls?
 
-| x0      | zero         | Zero                   | -- (Immutable)
-| x1      | ra           | Return address         | No
-| x2      | sp           | Stack pointer          | Yes
-| x3      | gp           | Global pointer         | -- (Unallocatable)
-| x4      | tp           | Thread pointer         | -- (Unallocatable)
-| x5-x7   | t0-t2        | Temporary registers    | No
-| x8-x9   | s0-s1        | Callee-saved registers | Yes
-| x10-x17 | a0-a7        | Argument registers     | No
-| x18-x27 | s2-s11       | Callee-saved registers | Yes
-| x28-x31 | t3-t6        | Temporary registers    | No
+| x0        | zero         | Zero                   | -- (Immutable)
+| x1        | ra           | Return address         | No
+| x2        | sp           | Stack pointer          | Yes
+| x3        | gp           | Global pointer         | -- (Unallocatable)
+| x4        | tp           | Thread pointer         | -- (Unallocatable)
+| x5 - x7   | t0 - t2      | Temporary registers    | No
+| x8 - x9   | s0 - s1      | Callee-saved registers | Yes
+| x10 - x17 | a0 - a7      | Argument registers     | No
+| x18 - x27 | s2 - s11     | Callee-saved registers | Yes
+| x28 - x31 | t3 - t6      | Temporary registers    | No
 |===
 
 In the standard ABI, procedures should not modify the integer registers tp and
@@ -32,15 +32,15 @@ it must reside in x8 (s0), the register remains callee-saved.
 
 === Floating-point Register Convention
 
-[%autowidth]
+[cols="1,1,2,2"]
 |===
-| Name    | ABI Mnemonic | Meaning                | Preserved across calls?
+| Name      | ABI Mnemonic | Meaning                | Preserved across calls?
 
-| f0-f7   | ft0-ft7      | Temporary registers    | No
-| f8-f9   | fs0-fs1      | Callee-saved registers | Yes*
-| f10-f17 | fa0-fa7      | Argument registers     | No
-| f18-f27 | fs2-fs11     | Callee-saved registers | Yes*
-| f28-f31 | ft8-ft11     | Temporary registers    | No
+| f0 - f7   | ft0 - ft7    | Temporary registers    | No
+| f8 - f9   | fs0 - fs1    | Callee-saved registers | Yes*
+| f10 - f17 | fa0 - fa7    | Argument registers     | No
+| f18 - f27 | fs2 - fs11   | Callee-saved registers | Yes*
+| f28 - f31 | ft8 - ft11   | Temporary registers    | No
 |===
 
 *: Floating-point values in callee-saved registers are only preserved across
@@ -304,7 +304,8 @@ There are two conventions for C/C++ type sizes and alignments.
 ILP32, ILP32F, ILP32D, and ILP32E:: Use the following type sizes and
 alignments (based on the ILP32 convention):
 +
-[%autowidth]
+[cols="4,>2,>3"]
+[width=60%]
 |===
 | Type                 | Size (Bytes)  | Alignment (Bytes)
 
@@ -327,7 +328,8 @@ alignments (based on the ILP32 convention):
 LP64, LP64F, LP64D, and LP64Q:: Use the following type sizes and
 alignments (based on the LP64 convention):
 +
-[%autowidth]
+[cols="4,>2,>3"]
+[width=60%]
 |===
 | Type                 | Size (Bytes)  | Alignment (Bytes)
 
@@ -395,7 +397,8 @@ systems. These are noted in this section.
 The following definitions apply for all ABIs defined in this document. Here
 there is no differentiation between ILP32 and LP64 abis.
 
-[%autowidth]
+[cols="2,>1,>1"]
+[width=80%]
 |===
 | Type    | Size (Bytes) | Alignment (Bytes)
 

--- a/riscv-dwarf.adoc
+++ b/riscv-dwarf.adoc
@@ -6,18 +6,19 @@ endif::[]
 
 == Dwarf Register Numbers
 
-[%autowidth]
+[cols="2,2,4"]
+[width=80%]
 |===
 | Dwarf Number | Register Name | Description
 
-| 0-31         | x0-x31        | Integer Registers
-| 32-63        | f0-f31        | Floating-point Registers
+| 0 - 31       | x0 - x31      | Integer Registers
+| 32 - 63      | f0 - f31      | Floating-point Registers
 | 64           |               | Alternate Frame Return Column
-| 65-95        |               | Reserved for future standard extensions
-| 96-127       | v0-v31        | Vector Registers
-| 128-3071     |               | Reserved for future standard extensions
-| 3072-4095    |               | Reserved for custom extensions
-| 4096-8191    |               | CSRs
+| 65 - 95      |               | Reserved for future standard extensions
+| 96 - 127     | v0 - v31      | Vector Registers
+| 128 - 3071   |               | Reserved for future standard extensions
+| 3072 - 4095  |               | Reserved for custom extensions
+| 4096 - 8191  |               | CSRs
 |===
 
 The alternate frame return column is meant to be used when unwinding from

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -91,7 +91,8 @@ this support is implicit.
 e_flags:: Describes the format of this ELF file.  These flags are used by the
 linker to disallow linking ELF files with incompatible ABIs together.
 +
-[%autowidth]
+[cols="1,2,1,1,3,5"]
+[width=80%]
 |===
 | Bit 0 | Bits 1 - 2 | Bit 3 | Bit 4 | Bits 5 - 23 | Bits 24 - 31
 
@@ -156,7 +157,8 @@ the ABI in use.
 The defined processor-specific `st_other` flags are listed in the following
 table.
 +
-[%autowidth]
+[cols="3,1"]
+[width=60%]
 |===
 | Name                 | Mask
 
@@ -185,7 +187,8 @@ Global Offset Table or DWARF meta data.
 The following table provides details of the RISC-V ELF relocations (instruction
 specific relocations show the instruction type in the Details column):
 
-[%autowidth]
+[cols=">1,5,2,2,2,3"]
+[width=100%]
 |===
 | Enum | ELF Reloc Type        | Description                     | Field       | Calculation | Details
 
@@ -304,7 +307,8 @@ The following table provides details on the variables used in relocation fields:
 
 The following table provides details on the constants used in relocation fields:
 
-[%autowidth]
+[cols="3,1"]
+[width=30%]
 |===
 | Name           | Value
 
@@ -511,7 +515,8 @@ There are various thread local storage models for statically allocated or
 dynamically allocated thread local storage. The following table lists the
 thread local storage models:
 
-[%autowidth]
+[cols="1,2,3"]
+[width=70%]
 |===
 | Mnemonic | Model          | Compiler flags
 
@@ -653,7 +658,8 @@ typedef struct
 
 The defined processor-specific section types are listed in following table.
 
-[%autowidth]
+[cols="3,3,1"]
+[width=80%]
 |===
 | Name                  | Value       | Attributes
 
@@ -664,7 +670,8 @@ The defined processor-specific section types are listed in following table.
 
 The following table lists the special sections defined by this ABI.
 
-[%autowidth]
+[cols="3,3,1"]
+[width=80%]
 |===
 | Name                       | Type                 | Attributes
 
@@ -678,7 +685,8 @@ The following table lists the special sections defined by this ABI.
 The defined processor-specific segment types are listed in following
 table.
 
-[%autowidth]
+[cols="3,2,3"]
+[width=80%]
 |===
 | Name                 | Value       | Meaning
 
@@ -696,7 +704,8 @@ There are no RISC-V specific definitions relating to ELF note sections.
 The defined processor-specific dynamic array tags are listed in the following
 table.
 
-[%autowidth]
+[cols="4,2,1,3,3"]
+[width=90%]
 |===
 | Name                | Value      | d_un  | Executable        | Shared Object
 
@@ -728,7 +737,8 @@ value if the tag number is even.
 
 ==== List of attributes
 
-[%autowidth]
+[cols="4,>2,2,5"]
+[width=100%]
 |===
 | Tag                                 | Value    | Parameter type | Description
 


### PR DESCRIPTION
- Manually specify the width percentage if there is word wrapping.
- Manually assign the width ratio of each column to prevent word
  wrapping if possible.
- Add space between `-` to improve readability.

Preview version:
[riscv-abi.pdf](https://github.com/riscv-non-isa/riscv-elf-psabi-doc/files/7277207/riscv-abi.pdf)