### PR TITLE
Add calling convention for system calls

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -320,6 +320,13 @@ NOTE: Although RV64GQ systems can technically use <<abi-lp64q,LP64Q>>, it is
 strongly recommended to use LP64D on general-purpose RV64GQ systems for
 compatibility with standard RV64G software.
 
+== Calling Convention for System Calls
+
+The calling convention for system calls does not fall within the scope of this
+document.
+Please refer to the documentation of the RISC-V execution environment interface
+(e.g OS kernel ABI, SBI).
+
 == C/C++ type details
 
 === C/C++ type sizes and alignments


### PR DESCRIPTION
Per discussion in last psABI, I added description to system call, I tried to find system call document for linux, but I can only find that on a [header file](https://github.com/torvalds/linux/blob/master/arch/riscv/include/asm/syscall.h)...

Actually we didn't specify anything about that, just a section to describe that's scope of respective OSs, and should find that from
the OS document.

