### PR TITLE
Revise for ELF File Header section

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -72,6 +72,9 @@ for more detail on how to mangle types.
 
 === File Header
 
+The section below lists the defined RISC-V-specific values for several ELF
+header fields.
+
 e_ident::
   EI_CLASS::: Specifies the base ISA, either RV32 or RV64.
   Linking RV32 and RV64 code together is not supported.

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -73,8 +73,8 @@ for more detail on how to mangle types.
 === File Header
 
 e_ident::
-  EI_CLASS::: Specifies the base ISA, either RV32 or RV64.  We don't let users
-  link RV32 and RV64 code together.
+  EI_CLASS::: Specifies the base ISA, either RV32 or RV64.
+  Linking RV32 and RV64 code together is not supported.
 +
 --
 [horizontal]

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -85,6 +85,14 @@ e_ident::
 ELFCLASS64:::: ELF-64 Object File
 ELFCLASS32:::: ELF-32 Object File
 --
+  EI_DATA::: Specifies the endianness; either big-endian or little-endian.
+  Linking big-endian and little-endian code together is not supported.
++
+--
+[horizontal]
+ELFDATA2LSB:::: Little-endian Object File
+ELFDATA2MSB:::: Big-endian Object File
+--
 
 e_machine:: Identifies the machine this ELF file targets.  Always contains
 EM_RISCV (243) for RISC-V ELF files.  We only support RISC-V v2 family ISAs,

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -73,7 +73,8 @@ for more detail on how to mangle types.
 === File Header
 
 The section below lists the defined RISC-V-specific values for several ELF
-header fields.
+header fields; any fields not listed in this section have no RISC-V-specific
+values.
 
 e_ident::
   EI_CLASS::: Specifies the base ISA, either RV32 or RV64.
@@ -84,8 +85,6 @@ e_ident::
 ELFCLASS64:::: ELF-64 Object File
 ELFCLASS32:::: ELF-32 Object File
 --
-
-e_type:: Nothing RISC-V specific.
 
 e_machine:: Identifies the machine this ELF file targets.  Always contains
 EM_RISCV (243) for RISC-V ELF files.  We only support RISC-V v2 family ISAs,


### PR DESCRIPTION
Address those review comment from @cmuellner

* 8.1.: "We don't let users..." -> Who is "We"
   Possible solution: "It is not possible to link RV32 and RV64 code together"
* 8.1: Missing description
  Possible solution: "The section below lists the defined RISC-V-specific values for several ELF header fields."
* 8.1.: The selection of header fields looks arbitrary.
  If only RISC-V specific amendments to ELF header are specified, then why
  having e_type there (with "Nothing RISC-V specific")?
  Possible solution: Either remove e_type or name all untouched header fields
  (e_type, e_version, e_entry, e_phoff, e_shoff, e_ehsize, e_phentsize, e_phnum, e_shentsize, e_shnum, e_shstrndx)
