### PR TITLE
riscv-elf: Use simpler equivalent expression for LO12 relocations

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -468,8 +468,8 @@ is followed by an I-Type instruction (add immediate or load) with an
 calculated like this:
 
 [horizontal]
-HI20:: `((symbol_address + 0x800) >> 12)`
-LO12:: `symbol_address - (hi20 << 12)`
+HI20:: `(symbol_address + 0x800) >> 12`
+LO12:: `symbol_address`
 
 The following assembly and relocations show loading an absolute address:
 
@@ -610,8 +610,8 @@ immediate on the add, load or store instruction the linker finds the
 instruction. The addresses for pair of relocations are calculated like this:
 
 [horizontal]
-HI20:: `((symbol_address - hi20_reloc_offset + 0x800) >> 12)`
-LO12:: `symbol_address - hi20_reloc_offset - (hi20 << 12)`
+HI20:: `(symbol_address - hi20_reloc_offset + 0x800) >> 12`
+LO12:: `symbol_address - hi20_reloc_offset`
 
 The successive instruction has a signed 12-bit immediate so the value of the
 preceding high 20-bit relocation may have 1 added to it.


### PR DESCRIPTION
Since LO12 only uses the low 12 bits of the value, subtracting a value
that's left-shifted by 12 cannot possibly have any effect. All this did
was sign-extend the value of lo12 from bit 12 upwards, which isn't
particularly useful, and just leads to confusion, since this unnecessary
(and backwards, given hi20's computation is based on lo12's immediate
being sign-extended, so feeding hi20 back into lo12's calculation is
somewhat circular) complexity has made its way into implementations in
toolchains and runtimes, which is bad.
