### PR TITLE
Clarify the range of medlow code model on rv64

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -21,7 +21,8 @@ in the current code model.
 === Small code model
 
 The small code model, or `medlow`, allows the code to address the whole RV32
-address space or the lower 2 GiB of the RV64 address space.
+address space or the lower 2 GiB and highest 2GiB of the RV64 address space
+(`0xFFFFFFFF7FFFF800` ~ `0xFFFFFFFFFFFFFFFF` and `0x0` ~ `0x000000007FFFF7FF`).
 By using the instructions `lui` and `ld` or `st`, when referring to an object, or
 `addi`, when calculating an address literal, for example,
 a 32-bit address literal can be produced.
@@ -42,6 +43,20 @@ an address in the `medlow` code model.
     # Calculate address
     lui  a0, %hi(symbol)
     addi a0, a0, %lo(symbol)
+----
+
+NOTE: The ranges on RV64 are not `0x0` ~ `0x000000007FFFFFFF` and
+`0xFFFFFFFF80000000` ~ `0xFFFFFFFFFFFFFFFF` due to RISC-V's sign-extension of
+immediates; the following code fragments show where the ranges come from:
+[,asm]
+----
+# Largest postive number:
+lui a0, 0x7ffff # a0 = 0x7ffff000
+addi a0, 0x7ff # a0 = a0 + 2047 = 0x000000007FFFF7FF
+
+# Smallest negative number:
+lui a0, 0x80000 # a0 = 0xffffffff80000000
+addi a0, a0, -0x800 # a0 = a0 + -2048 = 0xFFFFFFFF7FFFF800
 ----
 
 === Medium code model


### PR DESCRIPTION
Range of medlow code model is highest 2GiB and lowest 2GiB, but the spec
only say lowest 2GiB.

And also put the detail to show how those range come from.

Ref:
[1] https://www.sifive.com/blog/all-aboard-part-4-risc-v-code-models