### PR TITLE
Define XLEN and FLEN in `Terms and Abbreviations`

### DIFF
--- a/introduction.adoc
+++ b/introduction.adoc
@@ -27,4 +27,6 @@ This specification uses the following terms and abbreviations:
 | PC    | Program Counter
 | TLS   | Thread-Local Storage
 | NTBS  | Null-Terminated Byte String
+| XLEN  | The width of an integer register in bits
+| FLEN  | The width of a floating-point register in bits
 |===


### PR DESCRIPTION
We use XLEN and FLEN without define that, although that's widely used in
RISC-V world, but it would be great if we have explicitly define that.

Address review comment come from LLVM community[1].

[1] https://lists.llvm.org/pipermail/llvm-dev/2022-January/154600.html