### PR TITLE
Clairfy how struct pass in register

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -109,8 +109,8 @@ Aggregates whose total size is no more than XLEN bits are passed in
 a register, with the fields laid out as though they were passed in memory. If
 no register is available, the aggregate is passed on the stack.
 Aggregates whose total size is no more than 2×XLEN bits are passed in a pair
-of registers; if only one register is available, the first half is passed in
-a register and the second half is passed on the stack. If no registers are
+of registers; if only one register is available, the first XLEN bits are passed
+in a register and the remaining bits are passed on the stack. If no registers are
 available, the aggregate is passed on the stack. Bits unused due to
 padding, and bits past the end of an aggregate whose size in bits is not
 divisible by XLEN, are undefined.


### PR DESCRIPTION
`first half` is incorrect description if the struct size is less than 2 x XLEN
bits, for example a 48 bits struct passed in register pair for RV32, first
32-bits will hold in first register and the remaining 16-bits will hold
in second register, but `first half` means 24 bits in first register and
next 24 bits in next register, that is not we implement on both LLVM and
GCC.

Example code for demonstrate that:
```c
struct X {
   short x;
   int y;
} __attribute__ ((packed));

int foo(int a0, int a1, int a2, int a3, int a4, int a5, int a6, struct X a7)
{
   return a7.y;
}

int bar(struct X a7)
{
   return a7.y;
}
```

Address review comment come from LLVM community[1].

[1] https://lists.llvm.org/pipermail/llvm-dev/2022-January/154600.html