### PR TITLE
Clairfy address of struct return value is not required hold on return register

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -153,7 +153,8 @@ to the aligned register pair rule).
 Values are returned in the same manner as a first named argument of the same
 type would be passed.  If such an argument would have been passed by
 reference, the caller allocates memory for the return value, and passes the
-address as an implicit first parameter.
+address as an implicit first parameter, the address is not required hold on
+return register (a0).
 
 The stack grows downwards (towards lower addresses) and the stack pointer shall
 be aligned to a 128-bit boundary upon procedure entry.


### PR DESCRIPTION
psABI isn't specify the address should hold on return register(`a0`) or not,
GCC and LLVM are implement on different way here, GCC will hold the
address in return register, but LLVM won't.

It's an potential ABI incompatible change for GCC, fortunately the GCC
isn't rely that behavior, use return address rather than the rematerialization.

Following code can demonstrate this issue:

```
struct int4 {
   int   values[4];
};

struct int4 i4a;

struct int4 foo (struct int4 arg1)
{
  asm volatile ("li a0, 100 #force clobber a0":::"a0");
  return arg1;
}
```

Fix #238