### PR TITLE
riscv-cc: Describe that vxrm/vxsat is not preserved across calls

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -64,6 +64,8 @@ duration in accordance with C11 section 7.6 "Floating-point environment
 | v0-v31  |              | Temporary registers          | No
 | vl      |              | Vector length                | No
 | vtype   |              | Vector data type register    | No
+| vxrm    |              | Vector fixed-point rounding mode register    | No
+| vxsat   |              | Vector fixed-point saturation flag register  | No
 |===
 
 
@@ -71,7 +73,8 @@ Vector registers are not used for passing arguments or return values; we
 intend to define a new calling convention variant to allow that as a future
 software optimization.
 
-The `vxrm` and `vxsat` fields of `vcsr` have thread storage duration.
+The `vxrm` and `vxsat` fields of `vcsr` are not preserved across calls, which means
+their values are unknown on entry to/return from a call.
 
 Procedures may assume that `vstart` is zero upon entry. Procedures may assume
 that `vstart` is zero upon return from a procedure call.


### PR DESCRIPTION
There are discussions in https://github.com/riscv/riscv-v-spec/issues/739.
The reason that ISA makes the vx round mode only available in CSR is for encoding space.
I think we can make it non-preserved across calls to use it efficiently.