### PR TITLE
Add relocation `R_RISCV_RVC_COMP` for .align directives

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -401,7 +401,9 @@ Description:: Additional information about the relocation
                                             <| S + A - P
 .2+| 58      .2+| IRELATIVE     .2+| Runtime | _wordclass_       .2+| Relocation against a local ifunc symbol in a shared object
                                             <| `ifunc_resolver(B + A)`
-.2+| 59-191  .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
+.2+| 59      .2+| RVC_COMP      .2+| Static  | _word16_          .2+| Compressable instruction
+                                            <| `compressed_insn`
+.2+| 60-191  .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
                                             <|
 .2+| 192-255 .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for nonstandard ABI extensions
                                             <|


### PR DESCRIPTION
Binutils POC patch:
https://sourceware.org/pipermail/binutils/2022-March/120252.html

This RFC introduces a relocation that stores a compressed alternative to the emitted instruction. During the processing of .align directives, RVC instructions can be compressed or uncompressed to reach alignment with the minimum amount of nops.

The assembler emits this relocation for ops that aren't explicitly compressed in the assembly file and stores the compressed alternative in the addend.

```
Example:
nop
.balign 4
```

This currently emits:
```
c.nop
c.nop
```

With the RVC_COMP relocation, the linker can emit:
```
nop
```

Which eliminates one nop.

The drawback is that unlinked object files are larger, and the linker performs linker relaxation during this uncompressed worst case. A future optimization could compress instructions/eliminate nops before linker relaxation depending on whether the worst-case alignment is achievable using RVC insns.

This is my first time editing the psabi spec, so if I missed anything, please point it out and I will happily edit.

Thank you,
Patrick