### PR TITLE
Remove description of vxrm and vxsat from the spec

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -71,8 +71,6 @@ Vector registers are not used for passing arguments or return values; we
 intend to define a new calling convention variant to allow that as a future
 software optimization.
 
-The `vxrm` and `vxsat` fields of `vcsr` have thread storage duration.
-
 Procedures may assume that `vstart` is zero upon entry. Procedures may assume
 that `vstart` is zero upon return from a procedure call.
 


### PR DESCRIPTION
Pull out the `vxrm` and `vxsat` for this release and having a more complete discussion after 1.0 release.

Ref: https://github.com/riscv-non-isa/riscv-elf-psabi-doc/pull/256