### PR TITLE
riscv-elf: Rework specifying when STO_RISCV_VARIANT_CC is needed

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -112,9 +112,8 @@ table (GOT) for non-local symbol addresses.
 
 == Dynamic Linking
 
-Run-time linkers that use lazy binding must preserve all argument registers
-used in the standard calling convention for the ABI in use. Any functions that
-use additional argument registers must be annotated with
+Any functions that use registers in a way that is incompatible with
+the register convention of the ABI in use must be annotated with
 `STO_RISCV_VARIANT_CC`, as defined in <<Symbol Table>>.
 
 NOTE: Vector registers have a variable size depending on the hardware


### PR DESCRIPTION
This new text both captures using registers with a specific purpose in
the ABI (like SP) and also avoids creating incompatibilities with
glibc's LD_AUDIT by being more general, as discussed on libc-alpha.
