### PR TITLE
Add state statement in preamble

### DIFF
--- a/preamble.adoc
+++ b/preamble.adoc
@@ -1,3 +1,36 @@
+
+ifeval::["{revlifecycle}" == "dev"]
+[WARNING]
+.This document is in the link:http://riscv.org/spec-state[Development state]
+====
+Assume everything can change.
+====
+endif::[]
+ifeval::["{revlifecycle}" == "stable"]
+[WARNING]
+.This document is in the link:http://riscv.org/spec-state[Stable state]
+====
+Assume anything could still change, but limited change should be expected.
+====
+endif::[]
+ifeval::["{revlifecycle}" == "frozen"]
+[WARNING]
+.This document is in the link:http://riscv.org/spec-state[Frozen state]
+====
+Change is extremely unlikely. A high threshold will be used, and a change will
+only occur because of some truly critical issue being identified during the
+public review cycle.
+====
+endif::[]
+ifeval::["{revlifecycle}" == "ratified"]
+[WARNING]
+.This document is in the link:http://riscv.org/spec-state[Ratified state]
+====
+No changes are allowed. Any desired or needed changes can be the subject of
+a follow-on new extension. Ratified extensions are never revised.
+====
+endif::[]
+
 Contributors to all versions of the spec in alphabetical order:
 
 Alex Bradbury,

--- a/prelude.adoc
+++ b/prelude.adoc
@@ -1,21 +1,4 @@
 :company: RISC-V.org
-// These are the definitions from docs-template:
-//
-//   development: Assume everything can change
-//   stable: Assume everything could change
-//   frozen: If you implement this version you assume the risk that something
-//           might change because of the public review cycle but we expect
-//           little to no change.
-//   ratified: You can implement this and be assured nothing will change. If
-//             something needs to change due to an errata or enhancement, it
-//             will come out in a new extension. we do not revise extensions.
-//
-// These don't really make sense for our development process, so we replace
-// development with a single dev version that we brand as Pre-release, but
-// anything featuring in the document is implicitly frozen (in fact, stronger,
-// as frozen can still change in incompatible ways) as we cannot break ABI once
-// features are implemented in toolchains. Similarly stable is still frozen
-// just by another name for policy reasons.
 :revlifecycle: frozen
 :revnumber: 1.0-rc3-draft
 ifeval::["{revlifecycle}" == "dev"]


### PR DESCRIPTION
I guess the RVI's state statement might well fit for psABI, especially
we are open to accept new changes after 1.0 ratified, but I think we
could revise the state statement for ratified later.