### PR TITLE
introduction: Add note about memory model synchronization primitives

### DIFF
--- a/introduction.adoc
+++ b/introduction.adoc
@@ -9,6 +9,9 @@ This specification consists of the following three parts:
 - ELF specification
 - DWARF specification
 
+A future revision of this ABI will include a canonical set of mappings for
+memory model synchronization primitives.
+
 = Terms and Abbreviations
 
 This specification uses the following terms and abbreviations:


### PR DESCRIPTION
It was suggested to cover the memory model synchronization primitives
as part of the psABI documentation. Let's add a sentence to the
introduction that announces that for future revisions.

CC: @kito-cheng
