### PR TITLE
Clarify implications for fcsr

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -50,9 +50,10 @@ calls if they are no larger than the width of a floating-point register in the
 targeted ABI. Therefore, these registers can always be considered temporaries
 if targeting the base integer calling convention.
 
-The Floating-Point Control and Status Register (fcsr) must have thread storage
-duration in accordance with C11 section 7.6 "Floating-point environment
-<fenv.h>".
+In contexts where accesses or modifications to the C floating-point environment 
+(`fenv`) are meaningful, the state of `fenv` is coherent with that of the RISC-V 
+floating-point control and status register (`fcsr`). In these contexts, `fcsr` can
+be thought of as having thread storage duration.
 
 === Vector Register Convention
 

--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -51,9 +51,10 @@ targeted ABI. Therefore, these registers can always be considered temporaries
 if targeting the base integer calling convention.
 
 In contexts where accesses or modifications to the C floating-point environment 
-(`fenv`) are meaningful, the state of `fenv` is coherent with that of the RISC-V 
-floating-point control and status register (`fcsr`). In these contexts, `fcsr` can
-be thought of as having thread storage duration.
+(`fenv`) are meaningful, like when the `FENV_ACCESS` pragma is "on", the state of
+`fenv` is coherent with that of the RISC-V floating-point control and status 
+register (`fcsr`). In these contexts, `fcsr` can be thought of as having thread 
+storage duration.
 
 === Vector Register Convention
 


### PR DESCRIPTION
My understanding is that the psABI intends for `fcsr` to be the ABI manifestation of `fenv`, when the latter is relevant. With this understanding, I find the current wording to be misleading:

* `fcsr` is an object in the ISA, not the C language, so it is nonsensical to say it has "thread storage duration".
* It can be interpreted as imposing constraints on `fcsr` for all programs, even those that don't access/modify `fenv`.
* The relevant properties of `fenv` have been present since C99, so the specific reference to C11 is not meaningful.

This PR attempts to clarify the intent while addressing these three points. Your feedback is most welcome.