### PR TITLE
Describe content of non-argument/non-return register are unspecified …

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -85,6 +85,18 @@ Any procedure that does explicitly write `vstart` to a nonzero value must zero
 
 == Procedure Calling Convention
 
+This chapter defines standard calling conventions, and describes how to pass
+parameters and return values.
+
+Functions must follow the register convention defined in calling convention: the
+contents of any register without specifying it as an argument register
+in the calling convention are unspecified upon entry, and the content of any
+register without specifying it as a return value register or callee-saved in
+the calling convention are unspecified upon exit, the contents of all
+callee-saved registers must be restored to what was set on entry, and the
+contents of any fixed registers like `gp` and `tp` never change,
+
+
 NOTE: Calling convention for big-endian is *NOT* included in this specification
 yet, we intend to define that in future version of this specification.
 


### PR DESCRIPTION
…upon entry/exit.

Address @palmer-dabbelt's comment for vector register convention: https://github.com/riscv-non-isa/riscv-elf-psabi-doc/pull/286/commits/eefd8b0e5a963391e63a15b65e41ee2945c80534

Explicitly say those content is unspecified upon entry/exit, we only say those value will preserved across call or not.

In practice, those content of those register might be corrupt by PLT resolver (lazy binding), glibc's auditing feature or something else.

I tried describe that carfully to make sure that is still correct when we define another calling convention variant in future.

[1] https://man7.org/linux/man-pages/man7/rtld-audit.7.html
