### PR TITLE
Define vxrm/vxsat is not preserved across calls and unspecified upon entry field upon entry

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -64,12 +64,17 @@ duration in accordance with C11 section 7.6 "Floating-point environment
 | v0-v31  |              | Temporary registers          | No
 | vl      |              | Vector length                | No
 | vtype   |              | Vector data type register    | No
+| vxrm    |              | Vector fixed-point rounding mode register    | No
+| vxsat   |              | Vector fixed-point saturation flag register  | No
 |===
 
 
 Vector registers are not used for passing arguments or return values; we
 intend to define a new calling convention variant to allow that as a future
 software optimization.
+
+The `vxrm` and `vxsat` fields of `vcsr` are not preserved across calls and the
+value is unspecified upon entry.
 
 Procedures may assume that `vstart` is zero upon entry. Procedures may assume
 that `vstart` is zero upon return from a procedure call.


### PR DESCRIPTION
After discussion in #287, we realized that keeping the convention of `vxsat` and `vxrm` to be unspecified made the vector extension become unusable on the software side, because that might become an ABI breakage once we define that later, so we would like to define that within psABI 1.0 release.

Here is two potential proposals for `vxrm` and `vxsat` in #256:
- Same definition as `fcsr`, and followed the same convention as fenv.
- Define as `"not preserved across calls and unspecified upon entry"`.

Based on the discussion in #256 and few off list discussions, we have better understanding of the usage for `vxrm` and `vxsat` registers now, so we propose take the second proposal: “not preserved across calls and the value is unspecified upon entry” as the ABI for the `vxrm` and `vxsat` according following reasons:

- Using same policy as floating point environment might cause unnecessary overhead for maintain the convention described in C language specification : `"a function call does not alter its caller's floating-point control modes, clear its caller’s ﬂoating-point status ﬂags, nor depend on the state of its caller’s floating-point status ﬂags unless the function is so documented"`[1]; all existing libraries are *NOT* documented as might change fixed point rounding mode, that means we must backup and restore the content of `vxrm` and `vxsat` at those library functions when we implement those functions with vector fixed-point operations to ensure we didn't violate the convention.

- Another key difference between fixed-point rounding mode and floating point environment is fixed-point didn't have it own default rounding mode, and define one isn't meaningful because fixed-point rounding modes are likely to be setting to specific mode for most fixed-point algorithm, and might be changed frequently within a single algorithm implementation[2] - unlike floating point rounding modes are unlikely to change in most situation.

Based on the above reason, we believe that is the best choice for `vxrm` and `vxsat`.

[1] ISO/IEC 9899:2011: 7.6.3
[2] https://github.com/riscv/riscv-v-spec/issues/739