### PR TITLE
Require that lazily bound function follow the standard calling conven…

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -128,7 +128,7 @@ table (GOT) for non-local symbol addresses.
 == Dynamic Linking
 
 Any functions that use registers in a way that is incompatible with
-the register convention of the ABI in use must be annotated with
+the calling convention of the ABI in use must be annotated with
 `STO_RISCV_VARIANT_CC`, as defined in <<Symbol Table>>.
 
 NOTE: Vector registers have a variable size depending on the hardware


### PR DESCRIPTION
…tion

glibc's implementation of lazy symbol resolution relies on the function
being bound following some details of the calling convention that are
not included in the register convention, like the direction of stack
growth.  One could imaging building systems that can lazily resolve
functions while only relying on the register convention, but we've got a
decade or so of binaries that don't behave that way and we can't change
those.

Signed-off-by: Palmer Dabbelt <palmer@rivosinc.com>


Spited from #286