### PR TITLE
Tweak the wording for the note of STO_RISCV_VARIANT_CC.

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -134,9 +134,9 @@ the calling convention of the ABI in use must be annotated with
 NOTE: Vector registers have a variable size depending on the hardware
 implementation and can be quite large. Saving/restoring all these vector
 arguments in a run-time linker's lazy resolver would use a large amount of
-stack space and hurt performance. This attribute allows vector registers to
-not be part of the standard calling convention so run-time linkers are not
-required to save/restore them and can instead eagerly bind such functions.
+stack space and hurt performance. `STO_RISCV_VARIANT_CC` attribute will require
+the run-time linker to resolve the symbol directly to prevent saving/restoring
+any vector registers.
 
 == {Cpp} Name Mangling
 


### PR DESCRIPTION
The whole point of this VARIANT_CC bit is that we want to be able to use
V registers in _dl_resolve without saving them.  That requires that the
interface between the caller and the callee does not rely on the values
in the V registers.  That's a bit different than how we've histrorically
defined these temporary register clobbers, which is about the the
caller-side visibility into register changes.

Signed-off-by: Palmer Dabbelt <palmer@rivosinc.com>