### PR TITLE
Tweak wording in packed bitfield description

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -137,7 +137,7 @@ alignment boundary of its integer type is padded to begin at the next
 alignment boundary. For example, `struct { int x : 10; int y : 12; }` is
 a 32-bit type with `x` in bits 9-0, `y` in bits 21-10, and bits 31-22
 undefined.  By contrast, `struct { short x : 10; short y : 12; }` is a 32-bit
-type with `x` in bits 9-0, `y` in bits 27-16, and bits 31-28 and 15-10
+type with `x` in bits 9-0, `y` in bits 27-16, and bits 31-28 and bits 15-10
 undefined.
 
 Arguments passed by reference may be modified by the callee.


### PR DESCRIPTION
All other references to parts of the structure use "bits xx-yy". So
update the reference to bits 15-10 to do the same.