### PR TITLE
Escape __attribute__ and __packed__ using asciidoc inline passthrough

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -211,10 +211,10 @@ flattening, even in C++, unless they have nontrivial copy constructors or
 destructors.  Fields containing zero-length bit-fields are ignored while
 flattening.  Attributes such as `aligned` or `packed` do not interfere with a
 struct's eligibility for being passed in registers according to the rules
-below, i.e. `struct { int i; double d; }` and `struct
-__attribute__((__packed__)) { int i; double d }` are treated the same, as are
-`struct { float f; float g; }` and `struct { float f; float g __attribute__
-((aligned (8))); }`.
+below, i.e. `struct { int i; double d; }` and `+struct
+__attribute__((__packed__)) { int i; double d }+` are treated the same, as are
+`struct { float f; float g; }` and `+struct { float f; float g __attribute__
+((aligned (8))); }+`.
 
 A real floating-point argument is passed in a floating-point argument
 register if it is no more than ABI_FLEN bits wide and at least one floating-point


### PR DESCRIPTION
Unlike Markdown `` in Asciidoc simply applies monospace formatting
rather than literal text. This means `__attribute__` and `__packed__`
were being formatted incorrectly. This patch uses the inline passthrough
syntax <https://docs.asciidoctor.org/asciidoc/latest/pass/pass-macro/>
to avoid this.