### PR TITLE
Add note ensuring to emit relocations in the presence of relaxation

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -999,6 +999,11 @@ rather than to instruct the linker how to apply a relocation.
 The linker should only perform such relaxations when a R_RISCV_RELAX relocation
 is at the same position as a candidate relocation.
 
+As this transformation may delete bytes (and thus invalidate references that
+are commonly resolved at compile-time, such as intra-function jumps), code
+generators must in general ensure that relocations are always emitted when
+relaxation is enabled.
+
 [bibliography]
 == References
 


### PR DESCRIPTION
Alternate wording suggestions very welcome, but I feel it would be useful to say _something_ about this, even if it can be logically inferred from what is already there (and arguably the current wording isn't massively clear that bytes are actually deleted).