### PR TITLE
Clarify the detail rule of Tag_RISCV_arch

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -966,6 +966,21 @@ its based ISA. On the other hand, the architecture `RV32G` has to be presented
 as `RV32I2P0_M2P0_A2P0_F2P0_D2P0` in which the abbreviation `G` is expanded
 to the IMAFD combination with default versions of the standard extensions.
 
+The toolchain should normalized the architecture string into canonical order
+whcih defined in
+_The RISC-V Instruction Set Manual, Volume I: User-Level ISA, Document_ <<riscv-unpriv>>
+, expanded with all required extension and should add shorthand extension into
+architecture string if all expanded extensions are included in architecture
+string.
+
+NOTE: A shorthand extension is an extension that does not define any actual
+instructions, registers or behavior, but requires other extensions, such as the
+`zks` extension, which is defined in the cryptographic extension,
+`zks` extension is shorthand for `zbkb`, `zbkc`, `zbkx`, `zksed` and `zksh`, so
+the toolchain should normalize `rv32i_zbkb_zbkc_zbkx_zksed_zksh` to
+`rv32i_zbkb_zbkc_zbkx_zks_zksed_zksh`; `g` is an exception and does not apply to
+this rule.
+
 ===== Tag_RISCV_unaligned_access, 6, uleb128=value
 Tag_RISCV_unaligned_access denotes the code generation policy for this object
 file. Its values are defined as follows:
@@ -1015,3 +1030,7 @@ https://github.com/riscv-non-isa/riscv-asm-manual
 
 * [[[tls]]] "ELF Handling For Thread-Local Storage"
 https://www.akkadia.org/drepper/tls.pdf, Ulrich Drepper
+
+* [[[riscv-unpriv]]] "The RISC-V Instruction Set Manual, Volume I: User-Level
+ISA, Document", Editors Andrew Waterman and Krste Asanovi´c,
+RISC-V International.

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -963,11 +963,12 @@ separated by underline(`_`).
 Note that the version information for target architecture must be presented
 explicitly in the attribute and abbreviations must be expanded. The version
 information, if not given by `-march`, must agree with the default
-specified by the tool. For example, the architecture `RV32I` has to be recorded
-in the attribute as `RV32I2P0` in which `2P0` stands for the default version of
-its based ISA. On the other hand, the architecture `RV32G` has to be presented
-as `RV32I2P0_M2P0_A2P0_F2P0_D2P0` in which the abbreviation `G` is expanded
-to the IMAFD combination with default versions of the standard extensions.
+specified by the tool. For example, the architecture `rv32i` has to be recorded
+in the attribute as `rv32i2p1` in which `2p1` stands for the default version of
+its based ISA. On the other hand, the architecture `rv32g` has to be presented
+as `rv32i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0` in which the
+abbreviation `g` is expanded to the `imafd_zicsr_zifencei` combination with
+default versions of the standard extensions.
 
 The toolchain should normalized the architecture string into canonical order
 whcih defined in

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -957,6 +957,9 @@ Tag_RISCV_arch contains a string for the target architecture taken from
 the option `-march`. Different architectures will be integrated into a superset
 when object files are merged.
 
+Tag_RISCV_arch should be recorded in lowercase, and all extensions should be
+separated by underline(`_`).
+
 Note that the version information for target architecture must be presented
 explicitly in the attribute and abbreviations must be expanded. The version
 information, if not given by `-march`, must agree with the default


### PR DESCRIPTION
Canonical rule isn't clear on certain case, so clarify those corner case in the psABI, and also document `Tag_RISCV_arch` should be recorded in lowercase and separated by underline(`_`)