### PR TITLE
Document the behavior of larger-than-type bitfields

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -152,6 +152,13 @@ undefined.  By contrast, `struct { short x : 10; short y : 12; }` is a 32-bit
 type with `x` in bits 9-0, `y` in bits 27-16, and bits 31-28 and bits 15-10
 undefined.
 
+Bitfields may larger than its integer type, bits excess than its integer
+type will treat as padding bits, then padding to begin at the next alignment
+boundary. For example `struct { char x : 9; char y; }` is a 24 byte type with
+`x` in bits 7-0, `y` in bit 23-16, and bits 15-8 undefined,
+`struct { char x : 9; char y : 2 }` is a 16-bit type with `x` in bits 7-0, `y`
+in bit 10-9, and bit 8, bits 15-11 is undefined.
+
 Arguments passed by reference may be modified by the callee.
 
 Floating-point reals are passed the same way as aggregates of the same size;


### PR DESCRIPTION
C language does not allow that, but C++ language allows that, and has specify
the behavior, so we try to document what GCC and LLVM do for that, fortunately,
they have consistent behavior for larger-than-type bitfields.

C99 6.7.2.1-3:

```
The expression that specifies the width of a bit-field shall be an integer constant
expression that has nonnegative value that shall not exceed the number of bits in an object
of the type that is specifies
...
```

C++11 9.6-1:

```
The bit-ﬁeld attribute is not part of the type of the class member. The constant-expression shall be an integral constant
expression with a value greater than or equal to zero. The value of the integral constant expression may be larger than the
number of bits in the object representation (3.9) of the bit-ﬁeld’s type; in such cases the extra bits are used as padding bits
and do not participate in the value representation (3.9) of the bit-ﬁeld.
...
```