### PR TITLE
Deprecated Tag_RISCV_priv_spec* attributes

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -936,9 +936,9 @@ value if the tag number is even.
 | Tag_RISCV_stack_align               |        4 | uleb128        | Indicates the stack alignment requirement in bytes.
 | Tag_RISCV_arch                      |        5 | NTBS           | Indicates the target architecture of this object.
 | Tag_RISCV_unaligned_access          |        6 | uleb128        | Indicates whether to impose unaligned memory accesses in code generation.
-| Tag_RISCV_priv_spec                 |        8 | uleb128        | Indicates the major version of the privileged specification.
-| Tag_RISCV_priv_spec_minor           |       10 | uleb128        | Indicates the minor version of the privileged specification.
-| Tag_RISCV_priv_spec_revision        |       12 | uleb128        | Indicates the revision version of the privileged specification.
+| Tag_RISCV_priv_spec                 |        8 | uleb128        | *Deprecated*, indicates the major version of the privileged specification.
+| Tag_RISCV_priv_spec_minor           |       10 | uleb128        | *Deprecated*, indicates the minor version of the privileged specification.
+| Tag_RISCV_priv_spec_revision        |       12 | uleb128        | *Deprecated*, indicates the revision version of the privileged specification.
 | Reserved for non-standard attribute | >= 32768 | -              | -
 |===
 
@@ -980,6 +980,10 @@ file. Its values are defined as follows:
 ===== Tag_RISCV_priv_spec, 8, uleb128=version
 ===== Tag_RISCV_priv_spec_minor, 10, uleb128=version
 ===== Tag_RISCV_priv_spec_revision, 12, uleb128=version
+
+WARNING: Those three attributes are deprecated since RISC-V using extensions
+with version rather than a single privileged specification version scheme for
+privileged ISA.
 
 Tag_RISCV_priv_spec contains the major/minor/revision version information of
 the privileged specification. It will report errors if object files of different


### PR DESCRIPTION
Those attributes are not fit current version scheme for priv spec,
RISC-V using RISC-V using extensions with version rather than a single
privileged specification version scheme for privileged ISA now.