### PR TITLE
Add ELF flags for some profile-0.8 extensions

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -193,9 +193,9 @@ below.
 [cols="1,2,1,1,3,5"]
 [width=80%]
 |===
-| Bit 0 | Bits 1 - 2 | Bit 3 | Bit 4 | Bit 5 | Bits 6 - 23 | Bits 24 - 31
+| Bit 0 | Bits 1 - 2 | Bit 3 | Bit 4 | Bit 5 | Bit 6 | Bits 7 - 23 | Bits 24 - 31
 
-| RVC   | Float ABI  | RVE   | TSO   | RS64  | *Reserved*  | *Non-standard extensions*
+| RVC   | Float ABI  | RVE   | TSO   | RS64  | CCIF  | *Reserved*  | *Non-standard extensions*
 |===
 
 +
@@ -235,6 +235,9 @@ below.
 
   EF_RISCV_RS64 (0x0020)::: This bit is set when the binary requires the
   `Za64rs` extension.
+
+  EF_RISCV_CCIF (0x0040)::: This bit is set when the binary requires the
+  `Ziccif` extension.
 
 Until such a time that the *Reserved* bits (0x00ffffe0) are allocated by future
 versions of this specification, they shall not be set by standard software.

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -193,9 +193,9 @@ below.
 [cols="1,2,1,1,3,5"]
 [width=80%]
 |===
-| Bit 0 | Bits 1 - 2 | Bit 3 | Bit 4 | Bits 5 - 23 | Bits 24 - 31
+| Bit 0 | Bits 1 - 2 | Bit 3 | Bit 4 | Bit 5 | Bits 6 - 23 | Bits 24 - 31
 
-| RVC   | Float ABI  | RVE   | TSO   | *Reserved*  | *Non-standard extensions*
+| RVC   | Float ABI  | RVE   | TSO   | RS64  | *Reserved*  | *Non-standard extensions*
 |===
 
 +
@@ -232,6 +232,9 @@ below.
 
   EF_RISCV_TSO (0x0010)::: This bit is set when the binary requires the RVTSO
   memory consistency model.
+
+  EF_RISCV_RS64 (0x0020)::: This bit is set when the binary requires the
+  `Za64rs` extension.
 
 Until such a time that the *Reserved* bits (0x00ffffe0) are allocated by future
 versions of this specification, they shall not be set by standard software.


### PR DESCRIPTION
These are essentially the same as Ztso: they're new requirements on existing instructions, with no way to probe them in the ISA.  This treats them essentially the same way.