### PR TITLE
Open the relocation number more than 255

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -449,14 +449,23 @@ Description:: Additional information about the relocation
                                             <|
 .2+| 192-255 .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for nonstandard ABI extensions
                                             <|
+.2+| 256-2047 (0x100-0x7ff) .2+| *Reserved*           .2+| -       |                   .2+| Reserved for standard ABI extensions (RV64 only)
+                                            <|
+.2+| 2048-4095  (0x800-0xfff) .2+| *Reserved*         .2+| -       |                   .2+| Reserved for nonstandard ABI extensions (RV64 only)
+                                            <|
 |===
 
-Nonstandard extensions are free to use relocation numbers 192-255 for any
-purpose.  These relocations may conflict with other nonstandard extensions.
+Nonstandard extensions are free to use relocation numbers 192-255 and 2048-4095
+for any purpose.  These relocations may conflict with other nonstandard
+extensions.
 
 This section and later ones contain fragments written in assembler. The precise
 assembler syntax, including that of the relocations, is described in the
 _RISC-V Assembly Programmer's Manual_ <<rv-asm>>.
+
+Relocation type numbers more than 4096 on RV64 are reserved for future
+extension; the higher 20-bit of relocation type (ELF64_R_TYPE) might
+define for other use than identifying the relocation type.
 
 ==== Calculation Symbols
 


### PR DESCRIPTION
ELF64 format has support up to 32 bits for the relocation type, but currenlty we only define lower 8 bits due to the compatibility with ELF32, so the idea is open those range to RV64, and add RV64 only relocation to those range.

Also reserved part of relocation number to non-standard use.

We open up to 4096 and then still reserve the upper 20-bits for future extension, which might use those bits other than identifying the relocation type in the future, like SPARC64.

`RV64 only` might not precise enough, but enough for now since we don't have RV64 with ilp32*, this should fix when adding that.

---

NOTE: Updated, open up to 4096 rather than 2^32.