### PR TITLE
Define PLT-generating PC-Relative data relocation

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -445,7 +445,9 @@ Description:: Additional information about the relocation
                                             <| S + A - P
 .2+| 58      .2+| IRELATIVE     .2+| Dynamic | _wordclass_       .2+| Relocation against a non-preemptible ifunc symbol
                                             <| `ifunc_resolver(B + A)`
-.2+| 59-191  .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
+.2+| 59      .2+| PLT32         .2+| Static  | _word32_          .2+| 32-bit relative offset to a function or its PLT entry
+                                            <| S + A - P
+.2+| 60-191  .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
                                             <|
 .2+| 192-255 .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for nonstandard ABI extensions
                                             <|


### PR DESCRIPTION
We would like to introduce a new relocation type that works similarly to x86’s R_X86_64_PLT32 relocation and Arm’s R_AARCH64_PLT32 relocation.

In the “Procedure Calls” section of riscv-elf.adoc, we would add a new type “R_RISCV_PLT32” that follows the existing wording for the “R_RISCV_CALL” and “R_RISCV_CALL_PLT” types, but rather than modifying an instruction, it fills a whole, naturally aligned, 32-bit data location with the signed byte offset from its own location to the PLT entry for the target symbol. If the relocation is within +/-2GB of the target symbol, the linker may relax this to a R_RISCV_32_PCREL.

The purpose of this relocation is to enable the use of PIC-friendly ABI on RISC-V. Example is the [relative vtables ABI for C++](https://youtu.be/9HGKlDiJy8E). This ABI saves memory by moving vtables into .rodata by replacing each of the relocations that would constitute the vtable (R_RISCV_64, R_AARCH64_ABS64, R_X86_64_64) with PC-relative offsets, requiring no dynamic relocations. Instead of placing a pointer to each virtual method into the vtable, we would instead take the offset between the vtable and the virtual function which can be statically computed if the compiler knows both symbols are DSO-local. In the event the symbol is defined elsewhere, the vtable slots will instead contain offsets to the PLT entries for these functions. On both x86_64 and aarch64, Clang lowers the IR down to the offset between the PLT entry and the vtable, generating the PLT32 reloc we want, but we do not see this on riscv64 since the only PLT-generating relocs are `R_RISCV_CALL[_PLT]` which can only be applied to specific instructions (AUIPC+JALR) and not to data locations.