### PR TITLE
Add note for array with empty struct or union

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -270,13 +270,26 @@ hierarchy flattened, including any array fields.  That is, `struct { struct
 { float f[1]; } a[2]; }` and `struct { float f0; float f1; }` are
 treated the same.  Fields containing empty structs or unions are ignored while
 flattening, even in {Cpp}, unless they have nontrivial copy constructors or
-destructors.  Fields containing zero-length bit-fields are ignored while
-flattening.  Attributes such as `aligned` or `packed` do not interfere with a
-struct's eligibility for being passed in registers according to the rules
-below, i.e. `struct { int i; double d; }` and `+struct
+destructors.  Fields containing zero-length bit-fields or zero-length arrays are
+ignored while flattening.  Attributes such as `aligned` or `packed` do not
+interfere with a struct's eligibility for being passed in registers according
+to the rules below, i.e. `struct { int i; double d; }` and `+struct
 __attribute__((__packed__)) { int i; double d }+` are treated the same, as are
 `struct { float f; float g; }` and `+struct { float f; float g __attribute__
 ((aligned (8))); }+`.
+
+NOTE: One exceptional case for the flattening rule is an array of empty
+structs or unions; C treats it as an empty field, but {Cpp}
+treats it as a non-empty field since {Cpp} defines the size of an empty struct
+or union as 1. i.e. for `struct { struct {} e[1]; float f; }` as the first
+argument, C will treat it like `struct { float f; }` and pass `f` in `fa0` as
+described below, whereas {Cpp} will pass the pass the entire aggregate in `a0` 
+(XLEN = 64) or `a0` and `a1` (XLEN = 32), as described in the integer calling
+convention.
+Zero-length arrays of empty structs or union will be
+ignored for both C and {Cpp}. i.e. For `struct { struct {} e[0]; float f; };`,
+as the first argument, C and {Cpp} will treat it like `struct { float f; }`
+and pass `f` in `fa0` as described below.
 
 A real floating-point argument is passed in a floating-point argument
 register if it is no more than ABI_FLEN bits wide and at least one floating-point


### PR DESCRIPTION
Fix #358

The key point of this issue is C and C++ having different type size for array of empty struct or union, size of empty struct or union is 0 for C, and 1 for C++, and the size of array is type size multiplied by the length of the array.

Also checked AArch64 code gen, they also generated different code between C and C++, and ABI isn't explicitly describe this but has describe the size of array is type * length.