### PR TITLE
Add ABI information for __bf16

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -449,6 +449,7 @@ alignments (based on the ILP32 convention):
 | long                 |  4            |  4
 | long long            |  8            |  8
 | void *               |  4            |  4
+| +++__bf16+++         |  2            |  2
 | _Float16             |  2            |  2
 | float                |  4            |  4
 | double               |  8            |  8
@@ -475,6 +476,7 @@ alignments (based on the LP64 convention):
 | long long            |  8            |  8
 | +++__int128+++       | 16            | 16
 | void *               |  8            |  8
+| +++__bf16+++         |  2            |  2
 | _Float16             |  2            |  2
 | float                |  4            |  4
 | double               |  8            |  8
@@ -501,6 +503,8 @@ arguments are either `0` (`false`) or `1` (`true`).
 A null pointer (for all types) has the value zero.
 
 `_Float16` is as defined in the C ISO/IEC TS 18661-3 extension.
+
+`__bf16` has the same parameter passing and return rules as for `_Float16`.
 
 `_Complex` types have the same layout as a struct containing two fields of the
 corresponding real type (`float`, `double`, or `long double`), with the first

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -145,7 +145,8 @@ the _Itanium {Cpp} ABI_ <<itanium-cxx-abi>>;
 there are no RISC-V specific mangling rules.
 
 See the "Type encodings" section in _Itanium {Cpp} ABI_
-for more detail on how to mangle types.
+for more detail on how to mangle types. Note that `__bf16` is mangled in the
+same way as `std::bfloat16_t`.
 
 == ELF Object Files
 


### PR DESCRIPTION
At this point, posted just for comment. We'll need something covering this with the upcoming [RISC-V bfloat16 extension](https://github.com/riscv/riscv-bfloat16). I think this is all that is needed. For reference, see the [equivalent change in the x86-64 psABI](https://gitlab.com/x86-psABIs/x86-64-ABI/-/merge_requests/35/diffs).

I haven't carefully followed `__fp16` vs `_Float16` and `_BFloat16` vs `__bf16`. It looks like `__bf16` is preferred on other targets. Though this would also be a good moment to discuss that further if people feel that's not the right choice for RISC-V.

My understanding is that `_Float16` and `__bf16` will be passed in FPRs in exactly the same cases an FPR would be used for a `float` parameter or struct field. Again - please speak up if you feel that isn't what the psABI states.