### PR TITLE
Use "Procedure Linkage Table" for PLT

### DIFF
--- a/introduction.adoc
+++ b/introduction.adoc
@@ -26,7 +26,7 @@ This specification uses the following terms and abbreviations:
 | psABI             | Processor-Specific ABI
 | DWARF             | Debugging With Arbitrary Record Formats
 | GOT               | Global Offset Table
-| PLT               | Program Linkage Table
+| PLT               | Procedure Linkage Table
 | PC                | Program Counter
 | TLS               | Thread-Local Storage
 | NTBS              | Null-Terminated Byte String

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -567,11 +567,11 @@ directly, as can be done in static code, addresses are loaded from the GOT.
 This allows runtime binding to external objects and functions at the expense of
 a slightly higher runtime overhead for access to extern objects and functions.
 
-==== Program Linkage Table
+==== Procedure Linkage Table
 
-The PLT (Program Linkage Table) exists to allow function calls between
+The PLT (Procedure Linkage Table) exists to allow function calls between
 dynamically linked shared objects. Each dynamic object has its own
-GOT (Global Offset Table) and PLT (Program Linkage Table).
+GOT (Global Offset Table) and PLT (Procedure Linkage Table).
 
 The first entry of a shared object PLT is a special entry that calls
 `_dl_runtime_resolve` to resolve the GOT offset for the called function.


### PR DESCRIPTION
The conventional name for PLT is Procedure Linkage Table.