### PR TITLE
Relax gp could be platform specific register rather than reserved for…

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -28,6 +28,16 @@ endif::[]
 In the standard ABI, procedures should not modify the integer registers tp and
 gp, because signal handlers may rely upon their values.
 
+The presence of a frame pointer is optional.  If a frame pointer exists,
+it must reside in x8 (s0); the register remains callee-saved.
+
+If a platform requires use of a dedicated general-purpose register for a
+platform-specific purpose, it is recommended to use gp (x3). The platform ABI
+specification must document the use of this register. For such platforms, care
+must be taken to ensure all code (compiler generated or otherwise) avoids using
+gp in a way incompatible with the platform specific purpose, and that global
+pointer relaxation is disabled in the toolchain.
+
 === Frame Pointer Convention
 
 The presence of a frame pointer is optional.  If a frame pointer exists,


### PR DESCRIPTION
… linker relaxation

The usage of gp register has discussed serveral times (e.g. #298 and #305), and it reserved as special register used for linker relaxation, that could be improve perfomance and code size.

However it come with some limitation, like it can't applicable on shared libraries, and it also not work well when program come with large datas since the relaxable range is only +-2KiB.

Some platform like Haiku never use gp in the whole system, and also this might not useful in some baremetal system with specialized memory layout, so we might consider to release the gp usage with a non-hard-ABI-breakage way.