### PR TITLE
Define s11(x27) as a platform specific register

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -31,6 +31,12 @@ gp, because signal handlers may rely upon their values.
 The presence of a frame pointer is optional.  If a frame pointer exists,
 it must reside in x8 (s0); the register remains callee-saved.
 
+Platforms are free to reserve `s11(x27)` for use as a platform register. If a
+platform has need for a dedicated general-purpose register, then it should use
+`s11` register for that purpose. Should the platform forgo using `s11` in this
+role, then it should use `s11` as an additional callee-saved register. The
+platform ABI specification must document the use of this register.
+
 === Floating-point Register Convention
 
 .Floating-point register convention


### PR DESCRIPTION
The Procedure Call Standard for ARM(AArch64) defines x18 as a "Platform Register" if needed. This is useful for platforms to implement certain inter-procedural state. For instance, x18 is used on AArch64 as the shadow call stack register. Today, RISC-V has no analogous concept, but features like shadow call stack have already been implemented in LLVM using x18, which is problematic on RISC-V, since it prevents save/restore ranges from working as expected. Defining s11 as a platform register allows platforms to use features like shadow call stack without conflicting with planed feature like save/restore libcalls. 

resolves #370 