### PR TITLE
[Vector ABI] Type size and alignment for vector types.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,6 @@ $(NAME).pdf: $(NAME).adoc $(wildcard *.adoc) resources/themes/risc-v_spec-pdf.ym
 	    -a pdf-fontsdir=resources/fonts \
 	    -v \
 	    $< -o $@
+
+regen_vector_type_infos:
+	python3 gen_vector_type_infos.py > vector_type_infos.adoc

--- a/gen_vector_type_infos.py
+++ b/gen_vector_type_infos.py
@@ -1,0 +1,112 @@
+import subprocess
+import os
+import sys
+import math
+
+LMUL=["mf8", "mf4", "mf2", "m1", "m2", "m4", "m8"]
+NF=[2, 3, 4, 5, 6, 7, 8]
+SEW=[8, 16, 32, 64]
+TYPES = ["int", "uint", "float", "bfloat"]
+
+def lmul2nreg(lmul):
+    if (lmul.startswith("mf")):
+        return 1
+    else:
+        return int(lmul[1:])
+
+def lmul2num(lmul):
+    if (lmul.startswith("mf")):
+        if lmul=="mf8":
+            return 0.125
+        if lmul=="mf4":
+            return 0.25
+        if lmul=="mf2":
+            return 0.5
+        assert false
+    else:
+        return int(lmul[1:])
+
+def sizestr(lmul, nf=1):
+    sz_mul = lmul2num(lmul) * nf
+    if (sz_mul == 1):
+        return "(VLEN / 8)"
+    if (sz_mul > 1):
+        return "(VLEN / 8) * %g" %(sz_mul)
+    if (sz_mul < 1):
+        if (sz_mul == 0.5):
+            return "(VLEN / 8) / 2"
+        if (sz_mul == 0.25):
+            return "(VLEN / 8) / 4"
+        if (sz_mul == 0.125):
+            return "(VLEN / 8) / 8"
+        if (sz_mul == 0.375):
+            return "(VLEN / 8) * 0.375"
+        if (sz_mul == 0.625):
+            return "(VLEN / 8) * 0.625"
+        if (sz_mul == 0.75):
+            return "(VLEN / 8) * 0.75"
+        if (sz_mul == 0.875):
+            return "(VLEN / 8) * 0.875"
+        assert false
+
+def valid_type(sew, lmul, base_t, nf=1):
+    nreg = lmul2nreg(lmul)
+    if nreg * nf > 8:
+        return False
+    if t == "bfloat" and sew != 16:
+        return False
+    if t == "float" and sew == 16:
+        return False
+    return True
+
+def get_note(sew, lmul, base_t, nf=1):
+    ln = lmul2num(lmul)
+    x = (32 / sew * ln)
+    notes = []
+    if (32 / sew * ln) < 1:
+        notes += ["`*1`"]
+    if base_t == "float" and sew == 16:
+        notes += ["`*2`"]
+    if base_t == "bfloat":
+        notes += ["`*3`"]
+    if base_t == "float" and sew == 32:
+        notes += ["`*4`"]
+    if base_t == "float" and sew == 64:
+        notes += ["`*5`"]
+    if (base_t == "int" or base_t == "uint") and sew == 64:
+        notes += ["`*6`"]
+    return ", ".join(notes)
+
+print (".Type sizes and alignments for vector data types")
+print ("[cols=\"4,3,>3,>2\"]")
+print ("[width=80%]")
+print ("|===")
+print("| Internal Name | Type | Description")
+print("")
+
+for sew in SEW:
+    for lmul in LMUL:
+        for t in TYPES:
+            if not valid_type(sew, lmul, t):
+                continue
+            typename = "v%s%s%s_t" %(t, sew, lmul)
+            mname = "__rvv_" + typename
+            size = sizestr(lmul)
+            print ("| %-22s | %-20s | %-18s | %d" %(mname, typename, size, sew/8))
+
+print (".Type sizes and alignments for vector tuple types")
+print ("[cols=\"4,3,>3,>2\"]")
+print ("[width=80%]")
+print ("|===")
+
+print ("| Internal Name          | Type                 | Size (Bytes)  | Alignment (Bytes)")
+for sew in SEW:
+    for lmul in LMUL:
+        for nf in NF:
+            for t in TYPES:
+                if not valid_type(sew, lmul, t, nf):
+                    continue
+                typename = "v%s%s%sx%s_t" %(t, sew, lmul, nf)
+                mname = "__rvv_" + typename
+                size = sizestr(lmul, nf)
+                print ("| %-22s | %-20s | %-18s | %d" %(mname, typename, size, sew/8))

--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -626,6 +626,38 @@ of the vararg save area.  The `va_arg` macro will increment its `va_list`
 argument according to the size of the given type, taking into account the
 rules about 2×XLEN aligned arguments being passed in "aligned" register pairs.
 
+=== Vector type sizes and alignments
+
+This section defines the sizes and alignments for the vector types defined in
+the _RISC-V Vector Extension Intrinsic Document_<<rvv-intrinsic-doc>>.
+The actual size of each type is determined by the hardware configuration, which
+is based on the content of the `vlenb` register.
+
+There are three classes of vector types: the vector mask types, the vector
+data types and the vector tuple types.
+
+.Type sizes and alignments for vector mask types
+[cols="4,3,>3,>2"]
+[width=80%]
+|===
+| Internal Name              | Type                 | Size (Bytes)       | Alignment (Bytes)
+
+| __rvv_vbool1_t             | vbool1_t             |  VLENB             |  1
+| __rvv_vbool2_t             | vbool2_t             |  VLENB / 2         |  1
+| __rvv_vbool4_t             | vbool4_t             |  VLENB / 4         |  1
+| __rvv_vbool8_t             | vbool8_t             |  ceil(VLENB / 8)   |  1
+| __rvv_vbool16_t            | vbool16_t            |  ceil(VLENB / 16)  |  1
+| __rvv_vbool32_t            | vbool32_t            |  ceil(VLENB / 32)  |  1
+| __rvv_vbool64_t            | vbool64_t            |  ceil(VLENB / 64)  |  1
+|===
+
+include::vector_type_infos.adoc[]
+
+NOTE: The vector mask types utilize a portion of the space, while the remaining
+content may be undefined, both in the register and in memory.
+
+NOTE: Size must be a positive integer.
+
 [appendix]
 == Linux-specific ABI
 

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -142,12 +142,45 @@ any vector registers.
 
 {Cpp} name mangling for RISC-V follows
 the _Itanium {Cpp} ABI_ <<itanium-cxx-abi>>;
-there are no RISC-V specific mangling rules.
+plus mangling for RISC-V vector data types and vector mask types,
+which are defined in the following section.
 
 See the "Type encodings" section in _Itanium {Cpp} ABI_
 for more detail on how to mangle types. Note that `__bf16` is mangled in the
 same way as `std::bfloat16_t`.
 
+=== Name Mangling for Vector Data Types, Vector Mask Types and Vector Tuple Types.
+
+The vector data types and vector mask types, as defined in the section
+<<Vector type sizes and alignments>>, are treated as vendor-extended types in
+the _Itanium {Cpp} ABI_ <<itanium-cxx-abi>>. These mangled name for
+these types is `"u"<len>"__rvv_"<type-name>`. Specifically,
+prefixing the type name with `__rvv_`, which is prefixed by
+a decimal string indicating its length, which is prefixed by "u".
+
+For example:
+
+[,c]
+----
+    void foo(vint8m1_t x);
+----
+
+is mangled as
+[,c]
+----
+    _Z3foou15__rvv_vint8m1_t
+----
+[source,abnf]
+----
+mangled-name = "u" len "__rvv_" type-name
+
+len = nonzero *DIGIT
+nonzero = "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9"
+
+type-name = identifier-nondigit *identifier-char
+identifier-nondigit = ALPHA / "_"
+identifier-char = identifier-nondigit / "_"
+----
 == ELF Object Files
 
 The ELF object file format for RISC-V follows the
@@ -1977,3 +2010,6 @@ RISC-V International.
 
 * [[[riscv-zc-extension-group]]] "ZC* extension specification"
 https://github.com/riscv/riscv-code-size-reduction
+
+* [[[rvv-intrinsic-doc]]] "RISC-V Vector Extension Intrinsic Document"
+https://github.com/riscv-non-isa/rvv-intrinsic-doc

--- a/vector_type_infos.adoc
+++ b/vector_type_infos.adoc
@@ -1,0 +1,479 @@
+.Type sizes and alignments for vector data types
+[cols="4,3,>3,>2"]
+[width=80%]
+|===
+| Internal Name | Type | Description
+
+| __rvv_vint8mf8_t       | vint8mf8_t           | (VLEN / 8) / 8     | 1
+| __rvv_vuint8mf8_t      | vuint8mf8_t          | (VLEN / 8) / 8     | 1
+| __rvv_vfloat8mf8_t     | vfloat8mf8_t         | (VLEN / 8) / 8     | 1
+| __rvv_vint8mf4_t       | vint8mf4_t           | (VLEN / 8) / 4     | 1
+| __rvv_vuint8mf4_t      | vuint8mf4_t          | (VLEN / 8) / 4     | 1
+| __rvv_vfloat8mf4_t     | vfloat8mf4_t         | (VLEN / 8) / 4     | 1
+| __rvv_vint8mf2_t       | vint8mf2_t           | (VLEN / 8) / 2     | 1
+| __rvv_vuint8mf2_t      | vuint8mf2_t          | (VLEN / 8) / 2     | 1
+| __rvv_vfloat8mf2_t     | vfloat8mf2_t         | (VLEN / 8) / 2     | 1
+| __rvv_vint8m1_t        | vint8m1_t            | (VLEN / 8)         | 1
+| __rvv_vuint8m1_t       | vuint8m1_t           | (VLEN / 8)         | 1
+| __rvv_vfloat8m1_t      | vfloat8m1_t          | (VLEN / 8)         | 1
+| __rvv_vint8m2_t        | vint8m2_t            | (VLEN / 8) * 2     | 1
+| __rvv_vuint8m2_t       | vuint8m2_t           | (VLEN / 8) * 2     | 1
+| __rvv_vfloat8m2_t      | vfloat8m2_t          | (VLEN / 8) * 2     | 1
+| __rvv_vint8m4_t        | vint8m4_t            | (VLEN / 8) * 4     | 1
+| __rvv_vuint8m4_t       | vuint8m4_t           | (VLEN / 8) * 4     | 1
+| __rvv_vfloat8m4_t      | vfloat8m4_t          | (VLEN / 8) * 4     | 1
+| __rvv_vint8m8_t        | vint8m8_t            | (VLEN / 8) * 8     | 1
+| __rvv_vuint8m8_t       | vuint8m8_t           | (VLEN / 8) * 8     | 1
+| __rvv_vfloat8m8_t      | vfloat8m8_t          | (VLEN / 8) * 8     | 1
+| __rvv_vint16mf8_t      | vint16mf8_t          | (VLEN / 8) / 8     | 2
+| __rvv_vuint16mf8_t     | vuint16mf8_t         | (VLEN / 8) / 8     | 2
+| __rvv_vbfloat16mf8_t   | vbfloat16mf8_t       | (VLEN / 8) / 8     | 2
+| __rvv_vint16mf4_t      | vint16mf4_t          | (VLEN / 8) / 4     | 2
+| __rvv_vuint16mf4_t     | vuint16mf4_t         | (VLEN / 8) / 4     | 2
+| __rvv_vbfloat16mf4_t   | vbfloat16mf4_t       | (VLEN / 8) / 4     | 2
+| __rvv_vint16mf2_t      | vint16mf2_t          | (VLEN / 8) / 2     | 2
+| __rvv_vuint16mf2_t     | vuint16mf2_t         | (VLEN / 8) / 2     | 2
+| __rvv_vbfloat16mf2_t   | vbfloat16mf2_t       | (VLEN / 8) / 2     | 2
+| __rvv_vint16m1_t       | vint16m1_t           | (VLEN / 8)         | 2
+| __rvv_vuint16m1_t      | vuint16m1_t          | (VLEN / 8)         | 2
+| __rvv_vbfloat16m1_t    | vbfloat16m1_t        | (VLEN / 8)         | 2
+| __rvv_vint16m2_t       | vint16m2_t           | (VLEN / 8) * 2     | 2
+| __rvv_vuint16m2_t      | vuint16m2_t          | (VLEN / 8) * 2     | 2
+| __rvv_vbfloat16m2_t    | vbfloat16m2_t        | (VLEN / 8) * 2     | 2
+| __rvv_vint16m4_t       | vint16m4_t           | (VLEN / 8) * 4     | 2
+| __rvv_vuint16m4_t      | vuint16m4_t          | (VLEN / 8) * 4     | 2
+| __rvv_vbfloat16m4_t    | vbfloat16m4_t        | (VLEN / 8) * 4     | 2
+| __rvv_vint16m8_t       | vint16m8_t           | (VLEN / 8) * 8     | 2
+| __rvv_vuint16m8_t      | vuint16m8_t          | (VLEN / 8) * 8     | 2
+| __rvv_vbfloat16m8_t    | vbfloat16m8_t        | (VLEN / 8) * 8     | 2
+| __rvv_vint32mf8_t      | vint32mf8_t          | (VLEN / 8) / 8     | 4
+| __rvv_vuint32mf8_t     | vuint32mf8_t         | (VLEN / 8) / 8     | 4
+| __rvv_vfloat32mf8_t    | vfloat32mf8_t        | (VLEN / 8) / 8     | 4
+| __rvv_vint32mf4_t      | vint32mf4_t          | (VLEN / 8) / 4     | 4
+| __rvv_vuint32mf4_t     | vuint32mf4_t         | (VLEN / 8) / 4     | 4
+| __rvv_vfloat32mf4_t    | vfloat32mf4_t        | (VLEN / 8) / 4     | 4
+| __rvv_vint32mf2_t      | vint32mf2_t          | (VLEN / 8) / 2     | 4
+| __rvv_vuint32mf2_t     | vuint32mf2_t         | (VLEN / 8) / 2     | 4
+| __rvv_vfloat32mf2_t    | vfloat32mf2_t        | (VLEN / 8) / 2     | 4
+| __rvv_vint32m1_t       | vint32m1_t           | (VLEN / 8)         | 4
+| __rvv_vuint32m1_t      | vuint32m1_t          | (VLEN / 8)         | 4
+| __rvv_vfloat32m1_t     | vfloat32m1_t         | (VLEN / 8)         | 4
+| __rvv_vint32m2_t       | vint32m2_t           | (VLEN / 8) * 2     | 4
+| __rvv_vuint32m2_t      | vuint32m2_t          | (VLEN / 8) * 2     | 4
+| __rvv_vfloat32m2_t     | vfloat32m2_t         | (VLEN / 8) * 2     | 4
+| __rvv_vint32m4_t       | vint32m4_t           | (VLEN / 8) * 4     | 4
+| __rvv_vuint32m4_t      | vuint32m4_t          | (VLEN / 8) * 4     | 4
+| __rvv_vfloat32m4_t     | vfloat32m4_t         | (VLEN / 8) * 4     | 4
+| __rvv_vint32m8_t       | vint32m8_t           | (VLEN / 8) * 8     | 4
+| __rvv_vuint32m8_t      | vuint32m8_t          | (VLEN / 8) * 8     | 4
+| __rvv_vfloat32m8_t     | vfloat32m8_t         | (VLEN / 8) * 8     | 4
+| __rvv_vint64mf8_t      | vint64mf8_t          | (VLEN / 8) / 8     | 8
+| __rvv_vuint64mf8_t     | vuint64mf8_t         | (VLEN / 8) / 8     | 8
+| __rvv_vfloat64mf8_t    | vfloat64mf8_t        | (VLEN / 8) / 8     | 8
+| __rvv_vint64mf4_t      | vint64mf4_t          | (VLEN / 8) / 4     | 8
+| __rvv_vuint64mf4_t     | vuint64mf4_t         | (VLEN / 8) / 4     | 8
+| __rvv_vfloat64mf4_t    | vfloat64mf4_t        | (VLEN / 8) / 4     | 8
+| __rvv_vint64mf2_t      | vint64mf2_t          | (VLEN / 8) / 2     | 8
+| __rvv_vuint64mf2_t     | vuint64mf2_t         | (VLEN / 8) / 2     | 8
+| __rvv_vfloat64mf2_t    | vfloat64mf2_t        | (VLEN / 8) / 2     | 8
+| __rvv_vint64m1_t       | vint64m1_t           | (VLEN / 8)         | 8
+| __rvv_vuint64m1_t      | vuint64m1_t          | (VLEN / 8)         | 8
+| __rvv_vfloat64m1_t     | vfloat64m1_t         | (VLEN / 8)         | 8
+| __rvv_vint64m2_t       | vint64m2_t           | (VLEN / 8) * 2     | 8
+| __rvv_vuint64m2_t      | vuint64m2_t          | (VLEN / 8) * 2     | 8
+| __rvv_vfloat64m2_t     | vfloat64m2_t         | (VLEN / 8) * 2     | 8
+| __rvv_vint64m4_t       | vint64m4_t           | (VLEN / 8) * 4     | 8
+| __rvv_vuint64m4_t      | vuint64m4_t          | (VLEN / 8) * 4     | 8
+| __rvv_vfloat64m4_t     | vfloat64m4_t         | (VLEN / 8) * 4     | 8
+| __rvv_vint64m8_t       | vint64m8_t           | (VLEN / 8) * 8     | 8
+| __rvv_vuint64m8_t      | vuint64m8_t          | (VLEN / 8) * 8     | 8
+| __rvv_vfloat64m8_t     | vfloat64m8_t         | (VLEN / 8) * 8     | 8
+.Type sizes and alignments for vector tuple types
+[cols="4,3,>3,>2"]
+[width=80%]
+|===
+| Internal Name          | Type                 | Size (Bytes)  | Alignment (Bytes)
+| __rvv_vint8mf8x2_t     | vint8mf8x2_t         | (VLEN / 8) / 4     | 1
+| __rvv_vuint8mf8x2_t    | vuint8mf8x2_t        | (VLEN / 8) / 4     | 1
+| __rvv_vfloat8mf8x2_t   | vfloat8mf8x2_t       | (VLEN / 8) / 4     | 1
+| __rvv_vint8mf8x3_t     | vint8mf8x3_t         | (VLEN / 8) * 0.375 | 1
+| __rvv_vuint8mf8x3_t    | vuint8mf8x3_t        | (VLEN / 8) * 0.375 | 1
+| __rvv_vfloat8mf8x3_t   | vfloat8mf8x3_t       | (VLEN / 8) * 0.375 | 1
+| __rvv_vint8mf8x4_t     | vint8mf8x4_t         | (VLEN / 8) / 2     | 1
+| __rvv_vuint8mf8x4_t    | vuint8mf8x4_t        | (VLEN / 8) / 2     | 1
+| __rvv_vfloat8mf8x4_t   | vfloat8mf8x4_t       | (VLEN / 8) / 2     | 1
+| __rvv_vint8mf8x5_t     | vint8mf8x5_t         | (VLEN / 8) * 0.625 | 1
+| __rvv_vuint8mf8x5_t    | vuint8mf8x5_t        | (VLEN / 8) * 0.625 | 1
+| __rvv_vfloat8mf8x5_t   | vfloat8mf8x5_t       | (VLEN / 8) * 0.625 | 1
+| __rvv_vint8mf8x6_t     | vint8mf8x6_t         | (VLEN / 8) * 0.75  | 1
+| __rvv_vuint8mf8x6_t    | vuint8mf8x6_t        | (VLEN / 8) * 0.75  | 1
+| __rvv_vfloat8mf8x6_t   | vfloat8mf8x6_t       | (VLEN / 8) * 0.75  | 1
+| __rvv_vint8mf8x7_t     | vint8mf8x7_t         | (VLEN / 8) * 0.875 | 1
+| __rvv_vuint8mf8x7_t    | vuint8mf8x7_t        | (VLEN / 8) * 0.875 | 1
+| __rvv_vfloat8mf8x7_t   | vfloat8mf8x7_t       | (VLEN / 8) * 0.875 | 1
+| __rvv_vint8mf8x8_t     | vint8mf8x8_t         | (VLEN / 8)         | 1
+| __rvv_vuint8mf8x8_t    | vuint8mf8x8_t        | (VLEN / 8)         | 1
+| __rvv_vfloat8mf8x8_t   | vfloat8mf8x8_t       | (VLEN / 8)         | 1
+| __rvv_vint8mf4x2_t     | vint8mf4x2_t         | (VLEN / 8) / 2     | 1
+| __rvv_vuint8mf4x2_t    | vuint8mf4x2_t        | (VLEN / 8) / 2     | 1
+| __rvv_vfloat8mf4x2_t   | vfloat8mf4x2_t       | (VLEN / 8) / 2     | 1
+| __rvv_vint8mf4x3_t     | vint8mf4x3_t         | (VLEN / 8) * 0.75  | 1
+| __rvv_vuint8mf4x3_t    | vuint8mf4x3_t        | (VLEN / 8) * 0.75  | 1
+| __rvv_vfloat8mf4x3_t   | vfloat8mf4x3_t       | (VLEN / 8) * 0.75  | 1
+| __rvv_vint8mf4x4_t     | vint8mf4x4_t         | (VLEN / 8)         | 1
+| __rvv_vuint8mf4x4_t    | vuint8mf4x4_t        | (VLEN / 8)         | 1
+| __rvv_vfloat8mf4x4_t   | vfloat8mf4x4_t       | (VLEN / 8)         | 1
+| __rvv_vint8mf4x5_t     | vint8mf4x5_t         | (VLEN / 8) * 1.25  | 1
+| __rvv_vuint8mf4x5_t    | vuint8mf4x5_t        | (VLEN / 8) * 1.25  | 1
+| __rvv_vfloat8mf4x5_t   | vfloat8mf4x5_t       | (VLEN / 8) * 1.25  | 1
+| __rvv_vint8mf4x6_t     | vint8mf4x6_t         | (VLEN / 8) * 1.5   | 1
+| __rvv_vuint8mf4x6_t    | vuint8mf4x6_t        | (VLEN / 8) * 1.5   | 1
+| __rvv_vfloat8mf4x6_t   | vfloat8mf4x6_t       | (VLEN / 8) * 1.5   | 1
+| __rvv_vint8mf4x7_t     | vint8mf4x7_t         | (VLEN / 8) * 1.75  | 1
+| __rvv_vuint8mf4x7_t    | vuint8mf4x7_t        | (VLEN / 8) * 1.75  | 1
+| __rvv_vfloat8mf4x7_t   | vfloat8mf4x7_t       | (VLEN / 8) * 1.75  | 1
+| __rvv_vint8mf4x8_t     | vint8mf4x8_t         | (VLEN / 8) * 2     | 1
+| __rvv_vuint8mf4x8_t    | vuint8mf4x8_t        | (VLEN / 8) * 2     | 1
+| __rvv_vfloat8mf4x8_t   | vfloat8mf4x8_t       | (VLEN / 8) * 2     | 1
+| __rvv_vint8mf2x2_t     | vint8mf2x2_t         | (VLEN / 8)         | 1
+| __rvv_vuint8mf2x2_t    | vuint8mf2x2_t        | (VLEN / 8)         | 1
+| __rvv_vfloat8mf2x2_t   | vfloat8mf2x2_t       | (VLEN / 8)         | 1
+| __rvv_vint8mf2x3_t     | vint8mf2x3_t         | (VLEN / 8) * 1.5   | 1
+| __rvv_vuint8mf2x3_t    | vuint8mf2x3_t        | (VLEN / 8) * 1.5   | 1
+| __rvv_vfloat8mf2x3_t   | vfloat8mf2x3_t       | (VLEN / 8) * 1.5   | 1
+| __rvv_vint8mf2x4_t     | vint8mf2x4_t         | (VLEN / 8) * 2     | 1
+| __rvv_vuint8mf2x4_t    | vuint8mf2x4_t        | (VLEN / 8) * 2     | 1
+| __rvv_vfloat8mf2x4_t   | vfloat8mf2x4_t       | (VLEN / 8) * 2     | 1
+| __rvv_vint8mf2x5_t     | vint8mf2x5_t         | (VLEN / 8) * 2.5   | 1
+| __rvv_vuint8mf2x5_t    | vuint8mf2x5_t        | (VLEN / 8) * 2.5   | 1
+| __rvv_vfloat8mf2x5_t   | vfloat8mf2x5_t       | (VLEN / 8) * 2.5   | 1
+| __rvv_vint8mf2x6_t     | vint8mf2x6_t         | (VLEN / 8) * 3     | 1
+| __rvv_vuint8mf2x6_t    | vuint8mf2x6_t        | (VLEN / 8) * 3     | 1
+| __rvv_vfloat8mf2x6_t   | vfloat8mf2x6_t       | (VLEN / 8) * 3     | 1
+| __rvv_vint8mf2x7_t     | vint8mf2x7_t         | (VLEN / 8) * 3.5   | 1
+| __rvv_vuint8mf2x7_t    | vuint8mf2x7_t        | (VLEN / 8) * 3.5   | 1
+| __rvv_vfloat8mf2x7_t   | vfloat8mf2x7_t       | (VLEN / 8) * 3.5   | 1
+| __rvv_vint8mf2x8_t     | vint8mf2x8_t         | (VLEN / 8) * 4     | 1
+| __rvv_vuint8mf2x8_t    | vuint8mf2x8_t        | (VLEN / 8) * 4     | 1
+| __rvv_vfloat8mf2x8_t   | vfloat8mf2x8_t       | (VLEN / 8) * 4     | 1
+| __rvv_vint8m1x2_t      | vint8m1x2_t          | (VLEN / 8) * 2     | 1
+| __rvv_vuint8m1x2_t     | vuint8m1x2_t         | (VLEN / 8) * 2     | 1
+| __rvv_vfloat8m1x2_t    | vfloat8m1x2_t        | (VLEN / 8) * 2     | 1
+| __rvv_vint8m1x3_t      | vint8m1x3_t          | (VLEN / 8) * 3     | 1
+| __rvv_vuint8m1x3_t     | vuint8m1x3_t         | (VLEN / 8) * 3     | 1
+| __rvv_vfloat8m1x3_t    | vfloat8m1x3_t        | (VLEN / 8) * 3     | 1
+| __rvv_vint8m1x4_t      | vint8m1x4_t          | (VLEN / 8) * 4     | 1
+| __rvv_vuint8m1x4_t     | vuint8m1x4_t         | (VLEN / 8) * 4     | 1
+| __rvv_vfloat8m1x4_t    | vfloat8m1x4_t        | (VLEN / 8) * 4     | 1
+| __rvv_vint8m1x5_t      | vint8m1x5_t          | (VLEN / 8) * 5     | 1
+| __rvv_vuint8m1x5_t     | vuint8m1x5_t         | (VLEN / 8) * 5     | 1
+| __rvv_vfloat8m1x5_t    | vfloat8m1x5_t        | (VLEN / 8) * 5     | 1
+| __rvv_vint8m1x6_t      | vint8m1x6_t          | (VLEN / 8) * 6     | 1
+| __rvv_vuint8m1x6_t     | vuint8m1x6_t         | (VLEN / 8) * 6     | 1
+| __rvv_vfloat8m1x6_t    | vfloat8m1x6_t        | (VLEN / 8) * 6     | 1
+| __rvv_vint8m1x7_t      | vint8m1x7_t          | (VLEN / 8) * 7     | 1
+| __rvv_vuint8m1x7_t     | vuint8m1x7_t         | (VLEN / 8) * 7     | 1
+| __rvv_vfloat8m1x7_t    | vfloat8m1x7_t        | (VLEN / 8) * 7     | 1
+| __rvv_vint8m1x8_t      | vint8m1x8_t          | (VLEN / 8) * 8     | 1
+| __rvv_vuint8m1x8_t     | vuint8m1x8_t         | (VLEN / 8) * 8     | 1
+| __rvv_vfloat8m1x8_t    | vfloat8m1x8_t        | (VLEN / 8) * 8     | 1
+| __rvv_vint8m2x2_t      | vint8m2x2_t          | (VLEN / 8) * 4     | 1
+| __rvv_vuint8m2x2_t     | vuint8m2x2_t         | (VLEN / 8) * 4     | 1
+| __rvv_vfloat8m2x2_t    | vfloat8m2x2_t        | (VLEN / 8) * 4     | 1
+| __rvv_vint8m2x3_t      | vint8m2x3_t          | (VLEN / 8) * 6     | 1
+| __rvv_vuint8m2x3_t     | vuint8m2x3_t         | (VLEN / 8) * 6     | 1
+| __rvv_vfloat8m2x3_t    | vfloat8m2x3_t        | (VLEN / 8) * 6     | 1
+| __rvv_vint8m2x4_t      | vint8m2x4_t          | (VLEN / 8) * 8     | 1
+| __rvv_vuint8m2x4_t     | vuint8m2x4_t         | (VLEN / 8) * 8     | 1
+| __rvv_vfloat8m2x4_t    | vfloat8m2x4_t        | (VLEN / 8) * 8     | 1
+| __rvv_vint8m4x2_t      | vint8m4x2_t          | (VLEN / 8) * 8     | 1
+| __rvv_vuint8m4x2_t     | vuint8m4x2_t         | (VLEN / 8) * 8     | 1
+| __rvv_vfloat8m4x2_t    | vfloat8m4x2_t        | (VLEN / 8) * 8     | 1
+| __rvv_vint16mf8x2_t    | vint16mf8x2_t        | (VLEN / 8) / 4     | 2
+| __rvv_vuint16mf8x2_t   | vuint16mf8x2_t       | (VLEN / 8) / 4     | 2
+| __rvv_vbfloat16mf8x2_t | vbfloat16mf8x2_t     | (VLEN / 8) / 4     | 2
+| __rvv_vint16mf8x3_t    | vint16mf8x3_t        | (VLEN / 8) * 0.375 | 2
+| __rvv_vuint16mf8x3_t   | vuint16mf8x3_t       | (VLEN / 8) * 0.375 | 2
+| __rvv_vbfloat16mf8x3_t | vbfloat16mf8x3_t     | (VLEN / 8) * 0.375 | 2
+| __rvv_vint16mf8x4_t    | vint16mf8x4_t        | (VLEN / 8) / 2     | 2
+| __rvv_vuint16mf8x4_t   | vuint16mf8x4_t       | (VLEN / 8) / 2     | 2
+| __rvv_vbfloat16mf8x4_t | vbfloat16mf8x4_t     | (VLEN / 8) / 2     | 2
+| __rvv_vint16mf8x5_t    | vint16mf8x5_t        | (VLEN / 8) * 0.625 | 2
+| __rvv_vuint16mf8x5_t   | vuint16mf8x5_t       | (VLEN / 8) * 0.625 | 2
+| __rvv_vbfloat16mf8x5_t | vbfloat16mf8x5_t     | (VLEN / 8) * 0.625 | 2
+| __rvv_vint16mf8x6_t    | vint16mf8x6_t        | (VLEN / 8) * 0.75  | 2
+| __rvv_vuint16mf8x6_t   | vuint16mf8x6_t       | (VLEN / 8) * 0.75  | 2
+| __rvv_vbfloat16mf8x6_t | vbfloat16mf8x6_t     | (VLEN / 8) * 0.75  | 2
+| __rvv_vint16mf8x7_t    | vint16mf8x7_t        | (VLEN / 8) * 0.875 | 2
+| __rvv_vuint16mf8x7_t   | vuint16mf8x7_t       | (VLEN / 8) * 0.875 | 2
+| __rvv_vbfloat16mf8x7_t | vbfloat16mf8x7_t     | (VLEN / 8) * 0.875 | 2
+| __rvv_vint16mf8x8_t    | vint16mf8x8_t        | (VLEN / 8)         | 2
+| __rvv_vuint16mf8x8_t   | vuint16mf8x8_t       | (VLEN / 8)         | 2
+| __rvv_vbfloat16mf8x8_t | vbfloat16mf8x8_t     | (VLEN / 8)         | 2
+| __rvv_vint16mf4x2_t    | vint16mf4x2_t        | (VLEN / 8) / 2     | 2
+| __rvv_vuint16mf4x2_t   | vuint16mf4x2_t       | (VLEN / 8) / 2     | 2
+| __rvv_vbfloat16mf4x2_t | vbfloat16mf4x2_t     | (VLEN / 8) / 2     | 2
+| __rvv_vint16mf4x3_t    | vint16mf4x3_t        | (VLEN / 8) * 0.75  | 2
+| __rvv_vuint16mf4x3_t   | vuint16mf4x3_t       | (VLEN / 8) * 0.75  | 2
+| __rvv_vbfloat16mf4x3_t | vbfloat16mf4x3_t     | (VLEN / 8) * 0.75  | 2
+| __rvv_vint16mf4x4_t    | vint16mf4x4_t        | (VLEN / 8)         | 2
+| __rvv_vuint16mf4x4_t   | vuint16mf4x4_t       | (VLEN / 8)         | 2
+| __rvv_vbfloat16mf4x4_t | vbfloat16mf4x4_t     | (VLEN / 8)         | 2
+| __rvv_vint16mf4x5_t    | vint16mf4x5_t        | (VLEN / 8) * 1.25  | 2
+| __rvv_vuint16mf4x5_t   | vuint16mf4x5_t       | (VLEN / 8) * 1.25  | 2
+| __rvv_vbfloat16mf4x5_t | vbfloat16mf4x5_t     | (VLEN / 8) * 1.25  | 2
+| __rvv_vint16mf4x6_t    | vint16mf4x6_t        | (VLEN / 8) * 1.5   | 2
+| __rvv_vuint16mf4x6_t   | vuint16mf4x6_t       | (VLEN / 8) * 1.5   | 2
+| __rvv_vbfloat16mf4x6_t | vbfloat16mf4x6_t     | (VLEN / 8) * 1.5   | 2
+| __rvv_vint16mf4x7_t    | vint16mf4x7_t        | (VLEN / 8) * 1.75  | 2
+| __rvv_vuint16mf4x7_t   | vuint16mf4x7_t       | (VLEN / 8) * 1.75  | 2
+| __rvv_vbfloat16mf4x7_t | vbfloat16mf4x7_t     | (VLEN / 8) * 1.75  | 2
+| __rvv_vint16mf4x8_t    | vint16mf4x8_t        | (VLEN / 8) * 2     | 2
+| __rvv_vuint16mf4x8_t   | vuint16mf4x8_t       | (VLEN / 8) * 2     | 2
+| __rvv_vbfloat16mf4x8_t | vbfloat16mf4x8_t     | (VLEN / 8) * 2     | 2
+| __rvv_vint16mf2x2_t    | vint16mf2x2_t        | (VLEN / 8)         | 2
+| __rvv_vuint16mf2x2_t   | vuint16mf2x2_t       | (VLEN / 8)         | 2
+| __rvv_vbfloat16mf2x2_t | vbfloat16mf2x2_t     | (VLEN / 8)         | 2
+| __rvv_vint16mf2x3_t    | vint16mf2x3_t        | (VLEN / 8) * 1.5   | 2
+| __rvv_vuint16mf2x3_t   | vuint16mf2x3_t       | (VLEN / 8) * 1.5   | 2
+| __rvv_vbfloat16mf2x3_t | vbfloat16mf2x3_t     | (VLEN / 8) * 1.5   | 2
+| __rvv_vint16mf2x4_t    | vint16mf2x4_t        | (VLEN / 8) * 2     | 2
+| __rvv_vuint16mf2x4_t   | vuint16mf2x4_t       | (VLEN / 8) * 2     | 2
+| __rvv_vbfloat16mf2x4_t | vbfloat16mf2x4_t     | (VLEN / 8) * 2     | 2
+| __rvv_vint16mf2x5_t    | vint16mf2x5_t        | (VLEN / 8) * 2.5   | 2
+| __rvv_vuint16mf2x5_t   | vuint16mf2x5_t       | (VLEN / 8) * 2.5   | 2
+| __rvv_vbfloat16mf2x5_t | vbfloat16mf2x5_t     | (VLEN / 8) * 2.5   | 2
+| __rvv_vint16mf2x6_t    | vint16mf2x6_t        | (VLEN / 8) * 3     | 2
+| __rvv_vuint16mf2x6_t   | vuint16mf2x6_t       | (VLEN / 8) * 3     | 2
+| __rvv_vbfloat16mf2x6_t | vbfloat16mf2x6_t     | (VLEN / 8) * 3     | 2
+| __rvv_vint16mf2x7_t    | vint16mf2x7_t        | (VLEN / 8) * 3.5   | 2
+| __rvv_vuint16mf2x7_t   | vuint16mf2x7_t       | (VLEN / 8) * 3.5   | 2
+| __rvv_vbfloat16mf2x7_t | vbfloat16mf2x7_t     | (VLEN / 8) * 3.5   | 2
+| __rvv_vint16mf2x8_t    | vint16mf2x8_t        | (VLEN / 8) * 4     | 2
+| __rvv_vuint16mf2x8_t   | vuint16mf2x8_t       | (VLEN / 8) * 4     | 2
+| __rvv_vbfloat16mf2x8_t | vbfloat16mf2x8_t     | (VLEN / 8) * 4     | 2
+| __rvv_vint16m1x2_t     | vint16m1x2_t         | (VLEN / 8) * 2     | 2
+| __rvv_vuint16m1x2_t    | vuint16m1x2_t        | (VLEN / 8) * 2     | 2
+| __rvv_vbfloat16m1x2_t  | vbfloat16m1x2_t      | (VLEN / 8) * 2     | 2
+| __rvv_vint16m1x3_t     | vint16m1x3_t         | (VLEN / 8) * 3     | 2
+| __rvv_vuint16m1x3_t    | vuint16m1x3_t        | (VLEN / 8) * 3     | 2
+| __rvv_vbfloat16m1x3_t  | vbfloat16m1x3_t      | (VLEN / 8) * 3     | 2
+| __rvv_vint16m1x4_t     | vint16m1x4_t         | (VLEN / 8) * 4     | 2
+| __rvv_vuint16m1x4_t    | vuint16m1x4_t        | (VLEN / 8) * 4     | 2
+| __rvv_vbfloat16m1x4_t  | vbfloat16m1x4_t      | (VLEN / 8) * 4     | 2
+| __rvv_vint16m1x5_t     | vint16m1x5_t         | (VLEN / 8) * 5     | 2
+| __rvv_vuint16m1x5_t    | vuint16m1x5_t        | (VLEN / 8) * 5     | 2
+| __rvv_vbfloat16m1x5_t  | vbfloat16m1x5_t      | (VLEN / 8) * 5     | 2
+| __rvv_vint16m1x6_t     | vint16m1x6_t         | (VLEN / 8) * 6     | 2
+| __rvv_vuint16m1x6_t    | vuint16m1x6_t        | (VLEN / 8) * 6     | 2
+| __rvv_vbfloat16m1x6_t  | vbfloat16m1x6_t      | (VLEN / 8) * 6     | 2
+| __rvv_vint16m1x7_t     | vint16m1x7_t         | (VLEN / 8) * 7     | 2
+| __rvv_vuint16m1x7_t    | vuint16m1x7_t        | (VLEN / 8) * 7     | 2
+| __rvv_vbfloat16m1x7_t  | vbfloat16m1x7_t      | (VLEN / 8) * 7     | 2
+| __rvv_vint16m1x8_t     | vint16m1x8_t         | (VLEN / 8) * 8     | 2
+| __rvv_vuint16m1x8_t    | vuint16m1x8_t        | (VLEN / 8) * 8     | 2
+| __rvv_vbfloat16m1x8_t  | vbfloat16m1x8_t      | (VLEN / 8) * 8     | 2
+| __rvv_vint16m2x2_t     | vint16m2x2_t         | (VLEN / 8) * 4     | 2
+| __rvv_vuint16m2x2_t    | vuint16m2x2_t        | (VLEN / 8) * 4     | 2
+| __rvv_vbfloat16m2x2_t  | vbfloat16m2x2_t      | (VLEN / 8) * 4     | 2
+| __rvv_vint16m2x3_t     | vint16m2x3_t         | (VLEN / 8) * 6     | 2
+| __rvv_vuint16m2x3_t    | vuint16m2x3_t        | (VLEN / 8) * 6     | 2
+| __rvv_vbfloat16m2x3_t  | vbfloat16m2x3_t      | (VLEN / 8) * 6     | 2
+| __rvv_vint16m2x4_t     | vint16m2x4_t         | (VLEN / 8) * 8     | 2
+| __rvv_vuint16m2x4_t    | vuint16m2x4_t        | (VLEN / 8) * 8     | 2
+| __rvv_vbfloat16m2x4_t  | vbfloat16m2x4_t      | (VLEN / 8) * 8     | 2
+| __rvv_vint16m4x2_t     | vint16m4x2_t         | (VLEN / 8) * 8     | 2
+| __rvv_vuint16m4x2_t    | vuint16m4x2_t        | (VLEN / 8) * 8     | 2
+| __rvv_vbfloat16m4x2_t  | vbfloat16m4x2_t      | (VLEN / 8) * 8     | 2
+| __rvv_vint32mf8x2_t    | vint32mf8x2_t        | (VLEN / 8) / 4     | 4
+| __rvv_vuint32mf8x2_t   | vuint32mf8x2_t       | (VLEN / 8) / 4     | 4
+| __rvv_vfloat32mf8x2_t  | vfloat32mf8x2_t      | (VLEN / 8) / 4     | 4
+| __rvv_vint32mf8x3_t    | vint32mf8x3_t        | (VLEN / 8) * 0.375 | 4
+| __rvv_vuint32mf8x3_t   | vuint32mf8x3_t       | (VLEN / 8) * 0.375 | 4
+| __rvv_vfloat32mf8x3_t  | vfloat32mf8x3_t      | (VLEN / 8) * 0.375 | 4
+| __rvv_vint32mf8x4_t    | vint32mf8x4_t        | (VLEN / 8) / 2     | 4
+| __rvv_vuint32mf8x4_t   | vuint32mf8x4_t       | (VLEN / 8) / 2     | 4
+| __rvv_vfloat32mf8x4_t  | vfloat32mf8x4_t      | (VLEN / 8) / 2     | 4
+| __rvv_vint32mf8x5_t    | vint32mf8x5_t        | (VLEN / 8) * 0.625 | 4
+| __rvv_vuint32mf8x5_t   | vuint32mf8x5_t       | (VLEN / 8) * 0.625 | 4
+| __rvv_vfloat32mf8x5_t  | vfloat32mf8x5_t      | (VLEN / 8) * 0.625 | 4
+| __rvv_vint32mf8x6_t    | vint32mf8x6_t        | (VLEN / 8) * 0.75  | 4
+| __rvv_vuint32mf8x6_t   | vuint32mf8x6_t       | (VLEN / 8) * 0.75  | 4
+| __rvv_vfloat32mf8x6_t  | vfloat32mf8x6_t      | (VLEN / 8) * 0.75  | 4
+| __rvv_vint32mf8x7_t    | vint32mf8x7_t        | (VLEN / 8) * 0.875 | 4
+| __rvv_vuint32mf8x7_t   | vuint32mf8x7_t       | (VLEN / 8) * 0.875 | 4
+| __rvv_vfloat32mf8x7_t  | vfloat32mf8x7_t      | (VLEN / 8) * 0.875 | 4
+| __rvv_vint32mf8x8_t    | vint32mf8x8_t        | (VLEN / 8)         | 4
+| __rvv_vuint32mf8x8_t   | vuint32mf8x8_t       | (VLEN / 8)         | 4
+| __rvv_vfloat32mf8x8_t  | vfloat32mf8x8_t      | (VLEN / 8)         | 4
+| __rvv_vint32mf4x2_t    | vint32mf4x2_t        | (VLEN / 8) / 2     | 4
+| __rvv_vuint32mf4x2_t   | vuint32mf4x2_t       | (VLEN / 8) / 2     | 4
+| __rvv_vfloat32mf4x2_t  | vfloat32mf4x2_t      | (VLEN / 8) / 2     | 4
+| __rvv_vint32mf4x3_t    | vint32mf4x3_t        | (VLEN / 8) * 0.75  | 4
+| __rvv_vuint32mf4x3_t   | vuint32mf4x3_t       | (VLEN / 8) * 0.75  | 4
+| __rvv_vfloat32mf4x3_t  | vfloat32mf4x3_t      | (VLEN / 8) * 0.75  | 4
+| __rvv_vint32mf4x4_t    | vint32mf4x4_t        | (VLEN / 8)         | 4
+| __rvv_vuint32mf4x4_t   | vuint32mf4x4_t       | (VLEN / 8)         | 4
+| __rvv_vfloat32mf4x4_t  | vfloat32mf4x4_t      | (VLEN / 8)         | 4
+| __rvv_vint32mf4x5_t    | vint32mf4x5_t        | (VLEN / 8) * 1.25  | 4
+| __rvv_vuint32mf4x5_t   | vuint32mf4x5_t       | (VLEN / 8) * 1.25  | 4
+| __rvv_vfloat32mf4x5_t  | vfloat32mf4x5_t      | (VLEN / 8) * 1.25  | 4
+| __rvv_vint32mf4x6_t    | vint32mf4x6_t        | (VLEN / 8) * 1.5   | 4
+| __rvv_vuint32mf4x6_t   | vuint32mf4x6_t       | (VLEN / 8) * 1.5   | 4
+| __rvv_vfloat32mf4x6_t  | vfloat32mf4x6_t      | (VLEN / 8) * 1.5   | 4
+| __rvv_vint32mf4x7_t    | vint32mf4x7_t        | (VLEN / 8) * 1.75  | 4
+| __rvv_vuint32mf4x7_t   | vuint32mf4x7_t       | (VLEN / 8) * 1.75  | 4
+| __rvv_vfloat32mf4x7_t  | vfloat32mf4x7_t      | (VLEN / 8) * 1.75  | 4
+| __rvv_vint32mf4x8_t    | vint32mf4x8_t        | (VLEN / 8) * 2     | 4
+| __rvv_vuint32mf4x8_t   | vuint32mf4x8_t       | (VLEN / 8) * 2     | 4
+| __rvv_vfloat32mf4x8_t  | vfloat32mf4x8_t      | (VLEN / 8) * 2     | 4
+| __rvv_vint32mf2x2_t    | vint32mf2x2_t        | (VLEN / 8)         | 4
+| __rvv_vuint32mf2x2_t   | vuint32mf2x2_t       | (VLEN / 8)         | 4
+| __rvv_vfloat32mf2x2_t  | vfloat32mf2x2_t      | (VLEN / 8)         | 4
+| __rvv_vint32mf2x3_t    | vint32mf2x3_t        | (VLEN / 8) * 1.5   | 4
+| __rvv_vuint32mf2x3_t   | vuint32mf2x3_t       | (VLEN / 8) * 1.5   | 4
+| __rvv_vfloat32mf2x3_t  | vfloat32mf2x3_t      | (VLEN / 8) * 1.5   | 4
+| __rvv_vint32mf2x4_t    | vint32mf2x4_t        | (VLEN / 8) * 2     | 4
+| __rvv_vuint32mf2x4_t   | vuint32mf2x4_t       | (VLEN / 8) * 2     | 4
+| __rvv_vfloat32mf2x4_t  | vfloat32mf2x4_t      | (VLEN / 8) * 2     | 4
+| __rvv_vint32mf2x5_t    | vint32mf2x5_t        | (VLEN / 8) * 2.5   | 4
+| __rvv_vuint32mf2x5_t   | vuint32mf2x5_t       | (VLEN / 8) * 2.5   | 4
+| __rvv_vfloat32mf2x5_t  | vfloat32mf2x5_t      | (VLEN / 8) * 2.5   | 4
+| __rvv_vint32mf2x6_t    | vint32mf2x6_t        | (VLEN / 8) * 3     | 4
+| __rvv_vuint32mf2x6_t   | vuint32mf2x6_t       | (VLEN / 8) * 3     | 4
+| __rvv_vfloat32mf2x6_t  | vfloat32mf2x6_t      | (VLEN / 8) * 3     | 4
+| __rvv_vint32mf2x7_t    | vint32mf2x7_t        | (VLEN / 8) * 3.5   | 4
+| __rvv_vuint32mf2x7_t   | vuint32mf2x7_t       | (VLEN / 8) * 3.5   | 4
+| __rvv_vfloat32mf2x7_t  | vfloat32mf2x7_t      | (VLEN / 8) * 3.5   | 4
+| __rvv_vint32mf2x8_t    | vint32mf2x8_t        | (VLEN / 8) * 4     | 4
+| __rvv_vuint32mf2x8_t   | vuint32mf2x8_t       | (VLEN / 8) * 4     | 4
+| __rvv_vfloat32mf2x8_t  | vfloat32mf2x8_t      | (VLEN / 8) * 4     | 4
+| __rvv_vint32m1x2_t     | vint32m1x2_t         | (VLEN / 8) * 2     | 4
+| __rvv_vuint32m1x2_t    | vuint32m1x2_t        | (VLEN / 8) * 2     | 4
+| __rvv_vfloat32m1x2_t   | vfloat32m1x2_t       | (VLEN / 8) * 2     | 4
+| __rvv_vint32m1x3_t     | vint32m1x3_t         | (VLEN / 8) * 3     | 4
+| __rvv_vuint32m1x3_t    | vuint32m1x3_t        | (VLEN / 8) * 3     | 4
+| __rvv_vfloat32m1x3_t   | vfloat32m1x3_t       | (VLEN / 8) * 3     | 4
+| __rvv_vint32m1x4_t     | vint32m1x4_t         | (VLEN / 8) * 4     | 4
+| __rvv_vuint32m1x4_t    | vuint32m1x4_t        | (VLEN / 8) * 4     | 4
+| __rvv_vfloat32m1x4_t   | vfloat32m1x4_t       | (VLEN / 8) * 4     | 4
+| __rvv_vint32m1x5_t     | vint32m1x5_t         | (VLEN / 8) * 5     | 4
+| __rvv_vuint32m1x5_t    | vuint32m1x5_t        | (VLEN / 8) * 5     | 4
+| __rvv_vfloat32m1x5_t   | vfloat32m1x5_t       | (VLEN / 8) * 5     | 4
+| __rvv_vint32m1x6_t     | vint32m1x6_t         | (VLEN / 8) * 6     | 4
+| __rvv_vuint32m1x6_t    | vuint32m1x6_t        | (VLEN / 8) * 6     | 4
+| __rvv_vfloat32m1x6_t   | vfloat32m1x6_t       | (VLEN / 8) * 6     | 4
+| __rvv_vint32m1x7_t     | vint32m1x7_t         | (VLEN / 8) * 7     | 4
+| __rvv_vuint32m1x7_t    | vuint32m1x7_t        | (VLEN / 8) * 7     | 4
+| __rvv_vfloat32m1x7_t   | vfloat32m1x7_t       | (VLEN / 8) * 7     | 4
+| __rvv_vint32m1x8_t     | vint32m1x8_t         | (VLEN / 8) * 8     | 4
+| __rvv_vuint32m1x8_t    | vuint32m1x8_t        | (VLEN / 8) * 8     | 4
+| __rvv_vfloat32m1x8_t   | vfloat32m1x8_t       | (VLEN / 8) * 8     | 4
+| __rvv_vint32m2x2_t     | vint32m2x2_t         | (VLEN / 8) * 4     | 4
+| __rvv_vuint32m2x2_t    | vuint32m2x2_t        | (VLEN / 8) * 4     | 4
+| __rvv_vfloat32m2x2_t   | vfloat32m2x2_t       | (VLEN / 8) * 4     | 4
+| __rvv_vint32m2x3_t     | vint32m2x3_t         | (VLEN / 8) * 6     | 4
+| __rvv_vuint32m2x3_t    | vuint32m2x3_t        | (VLEN / 8) * 6     | 4
+| __rvv_vfloat32m2x3_t   | vfloat32m2x3_t       | (VLEN / 8) * 6     | 4
+| __rvv_vint32m2x4_t     | vint32m2x4_t         | (VLEN / 8) * 8     | 4
+| __rvv_vuint32m2x4_t    | vuint32m2x4_t        | (VLEN / 8) * 8     | 4
+| __rvv_vfloat32m2x4_t   | vfloat32m2x4_t       | (VLEN / 8) * 8     | 4
+| __rvv_vint32m4x2_t     | vint32m4x2_t         | (VLEN / 8) * 8     | 4
+| __rvv_vuint32m4x2_t    | vuint32m4x2_t        | (VLEN / 8) * 8     | 4
+| __rvv_vfloat32m4x2_t   | vfloat32m4x2_t       | (VLEN / 8) * 8     | 4
+| __rvv_vint64mf8x2_t    | vint64mf8x2_t        | (VLEN / 8) / 4     | 8
+| __rvv_vuint64mf8x2_t   | vuint64mf8x2_t       | (VLEN / 8) / 4     | 8
+| __rvv_vfloat64mf8x2_t  | vfloat64mf8x2_t      | (VLEN / 8) / 4     | 8
+| __rvv_vint64mf8x3_t    | vint64mf8x3_t        | (VLEN / 8) * 0.375 | 8
+| __rvv_vuint64mf8x3_t   | vuint64mf8x3_t       | (VLEN / 8) * 0.375 | 8
+| __rvv_vfloat64mf8x3_t  | vfloat64mf8x3_t      | (VLEN / 8) * 0.375 | 8
+| __rvv_vint64mf8x4_t    | vint64mf8x4_t        | (VLEN / 8) / 2     | 8
+| __rvv_vuint64mf8x4_t   | vuint64mf8x4_t       | (VLEN / 8) / 2     | 8
+| __rvv_vfloat64mf8x4_t  | vfloat64mf8x4_t      | (VLEN / 8) / 2     | 8
+| __rvv_vint64mf8x5_t    | vint64mf8x5_t        | (VLEN / 8) * 0.625 | 8
+| __rvv_vuint64mf8x5_t   | vuint64mf8x5_t       | (VLEN / 8) * 0.625 | 8
+| __rvv_vfloat64mf8x5_t  | vfloat64mf8x5_t      | (VLEN / 8) * 0.625 | 8
+| __rvv_vint64mf8x6_t    | vint64mf8x6_t        | (VLEN / 8) * 0.75  | 8
+| __rvv_vuint64mf8x6_t   | vuint64mf8x6_t       | (VLEN / 8) * 0.75  | 8
+| __rvv_vfloat64mf8x6_t  | vfloat64mf8x6_t      | (VLEN / 8) * 0.75  | 8
+| __rvv_vint64mf8x7_t    | vint64mf8x7_t        | (VLEN / 8) * 0.875 | 8
+| __rvv_vuint64mf8x7_t   | vuint64mf8x7_t       | (VLEN / 8) * 0.875 | 8
+| __rvv_vfloat64mf8x7_t  | vfloat64mf8x7_t      | (VLEN / 8) * 0.875 | 8
+| __rvv_vint64mf8x8_t    | vint64mf8x8_t        | (VLEN / 8)         | 8
+| __rvv_vuint64mf8x8_t   | vuint64mf8x8_t       | (VLEN / 8)         | 8
+| __rvv_vfloat64mf8x8_t  | vfloat64mf8x8_t      | (VLEN / 8)         | 8
+| __rvv_vint64mf4x2_t    | vint64mf4x2_t        | (VLEN / 8) / 2     | 8
+| __rvv_vuint64mf4x2_t   | vuint64mf4x2_t       | (VLEN / 8) / 2     | 8
+| __rvv_vfloat64mf4x2_t  | vfloat64mf4x2_t      | (VLEN / 8) / 2     | 8
+| __rvv_vint64mf4x3_t    | vint64mf4x3_t        | (VLEN / 8) * 0.75  | 8
+| __rvv_vuint64mf4x3_t   | vuint64mf4x3_t       | (VLEN / 8) * 0.75  | 8
+| __rvv_vfloat64mf4x3_t  | vfloat64mf4x3_t      | (VLEN / 8) * 0.75  | 8
+| __rvv_vint64mf4x4_t    | vint64mf4x4_t        | (VLEN / 8)         | 8
+| __rvv_vuint64mf4x4_t   | vuint64mf4x4_t       | (VLEN / 8)         | 8
+| __rvv_vfloat64mf4x4_t  | vfloat64mf4x4_t      | (VLEN / 8)         | 8
+| __rvv_vint64mf4x5_t    | vint64mf4x5_t        | (VLEN / 8) * 1.25  | 8
+| __rvv_vuint64mf4x5_t   | vuint64mf4x5_t       | (VLEN / 8) * 1.25  | 8
+| __rvv_vfloat64mf4x5_t  | vfloat64mf4x5_t      | (VLEN / 8) * 1.25  | 8
+| __rvv_vint64mf4x6_t    | vint64mf4x6_t        | (VLEN / 8) * 1.5   | 8
+| __rvv_vuint64mf4x6_t   | vuint64mf4x6_t       | (VLEN / 8) * 1.5   | 8
+| __rvv_vfloat64mf4x6_t  | vfloat64mf4x6_t      | (VLEN / 8) * 1.5   | 8
+| __rvv_vint64mf4x7_t    | vint64mf4x7_t        | (VLEN / 8) * 1.75  | 8
+| __rvv_vuint64mf4x7_t   | vuint64mf4x7_t       | (VLEN / 8) * 1.75  | 8
+| __rvv_vfloat64mf4x7_t  | vfloat64mf4x7_t      | (VLEN / 8) * 1.75  | 8
+| __rvv_vint64mf4x8_t    | vint64mf4x8_t        | (VLEN / 8) * 2     | 8
+| __rvv_vuint64mf4x8_t   | vuint64mf4x8_t       | (VLEN / 8) * 2     | 8
+| __rvv_vfloat64mf4x8_t  | vfloat64mf4x8_t      | (VLEN / 8) * 2     | 8
+| __rvv_vint64mf2x2_t    | vint64mf2x2_t        | (VLEN / 8)         | 8
+| __rvv_vuint64mf2x2_t   | vuint64mf2x2_t       | (VLEN / 8)         | 8
+| __rvv_vfloat64mf2x2_t  | vfloat64mf2x2_t      | (VLEN / 8)         | 8
+| __rvv_vint64mf2x3_t    | vint64mf2x3_t        | (VLEN / 8) * 1.5   | 8
+| __rvv_vuint64mf2x3_t   | vuint64mf2x3_t       | (VLEN / 8) * 1.5   | 8
+| __rvv_vfloat64mf2x3_t  | vfloat64mf2x3_t      | (VLEN / 8) * 1.5   | 8
+| __rvv_vint64mf2x4_t    | vint64mf2x4_t        | (VLEN / 8) * 2     | 8
+| __rvv_vuint64mf2x4_t   | vuint64mf2x4_t       | (VLEN / 8) * 2     | 8
+| __rvv_vfloat64mf2x4_t  | vfloat64mf2x4_t      | (VLEN / 8) * 2     | 8
+| __rvv_vint64mf2x5_t    | vint64mf2x5_t        | (VLEN / 8) * 2.5   | 8
+| __rvv_vuint64mf2x5_t   | vuint64mf2x5_t       | (VLEN / 8) * 2.5   | 8
+| __rvv_vfloat64mf2x5_t  | vfloat64mf2x5_t      | (VLEN / 8) * 2.5   | 8
+| __rvv_vint64mf2x6_t    | vint64mf2x6_t        | (VLEN / 8) * 3     | 8
+| __rvv_vuint64mf2x6_t   | vuint64mf2x6_t       | (VLEN / 8) * 3     | 8
+| __rvv_vfloat64mf2x6_t  | vfloat64mf2x6_t      | (VLEN / 8) * 3     | 8
+| __rvv_vint64mf2x7_t    | vint64mf2x7_t        | (VLEN / 8) * 3.5   | 8
+| __rvv_vuint64mf2x7_t   | vuint64mf2x7_t       | (VLEN / 8) * 3.5   | 8
+| __rvv_vfloat64mf2x7_t  | vfloat64mf2x7_t      | (VLEN / 8) * 3.5   | 8
+| __rvv_vint64mf2x8_t    | vint64mf2x8_t        | (VLEN / 8) * 4     | 8
+| __rvv_vuint64mf2x8_t   | vuint64mf2x8_t       | (VLEN / 8) * 4     | 8
+| __rvv_vfloat64mf2x8_t  | vfloat64mf2x8_t      | (VLEN / 8) * 4     | 8
+| __rvv_vint64m1x2_t     | vint64m1x2_t         | (VLEN / 8) * 2     | 8
+| __rvv_vuint64m1x2_t    | vuint64m1x2_t        | (VLEN / 8) * 2     | 8
+| __rvv_vfloat64m1x2_t   | vfloat64m1x2_t       | (VLEN / 8) * 2     | 8
+| __rvv_vint64m1x3_t     | vint64m1x3_t         | (VLEN / 8) * 3     | 8
+| __rvv_vuint64m1x3_t    | vuint64m1x3_t        | (VLEN / 8) * 3     | 8
+| __rvv_vfloat64m1x3_t   | vfloat64m1x3_t       | (VLEN / 8) * 3     | 8
+| __rvv_vint64m1x4_t     | vint64m1x4_t         | (VLEN / 8) * 4     | 8
+| __rvv_vuint64m1x4_t    | vuint64m1x4_t        | (VLEN / 8) * 4     | 8
+| __rvv_vfloat64m1x4_t   | vfloat64m1x4_t       | (VLEN / 8) * 4     | 8
+| __rvv_vint64m1x5_t     | vint64m1x5_t         | (VLEN / 8) * 5     | 8
+| __rvv_vuint64m1x5_t    | vuint64m1x5_t        | (VLEN / 8) * 5     | 8
+| __rvv_vfloat64m1x5_t   | vfloat64m1x5_t       | (VLEN / 8) * 5     | 8
+| __rvv_vint64m1x6_t     | vint64m1x6_t         | (VLEN / 8) * 6     | 8
+| __rvv_vuint64m1x6_t    | vuint64m1x6_t        | (VLEN / 8) * 6     | 8
+| __rvv_vfloat64m1x6_t   | vfloat64m1x6_t       | (VLEN / 8) * 6     | 8
+| __rvv_vint64m1x7_t     | vint64m1x7_t         | (VLEN / 8) * 7     | 8
+| __rvv_vuint64m1x7_t    | vuint64m1x7_t        | (VLEN / 8) * 7     | 8
+| __rvv_vfloat64m1x7_t   | vfloat64m1x7_t       | (VLEN / 8) * 7     | 8
+| __rvv_vint64m1x8_t     | vint64m1x8_t         | (VLEN / 8) * 8     | 8
+| __rvv_vuint64m1x8_t    | vuint64m1x8_t        | (VLEN / 8) * 8     | 8
+| __rvv_vfloat64m1x8_t   | vfloat64m1x8_t       | (VLEN / 8) * 8     | 8
+| __rvv_vint64m2x2_t     | vint64m2x2_t         | (VLEN / 8) * 4     | 8
+| __rvv_vuint64m2x2_t    | vuint64m2x2_t        | (VLEN / 8) * 4     | 8
+| __rvv_vfloat64m2x2_t   | vfloat64m2x2_t       | (VLEN / 8) * 4     | 8
+| __rvv_vint64m2x3_t     | vint64m2x3_t         | (VLEN / 8) * 6     | 8
+| __rvv_vuint64m2x3_t    | vuint64m2x3_t        | (VLEN / 8) * 6     | 8
+| __rvv_vfloat64m2x3_t   | vfloat64m2x3_t       | (VLEN / 8) * 6     | 8
+| __rvv_vint64m2x4_t     | vint64m2x4_t         | (VLEN / 8) * 8     | 8
+| __rvv_vuint64m2x4_t    | vuint64m2x4_t        | (VLEN / 8) * 8     | 8
+| __rvv_vfloat64m2x4_t   | vfloat64m2x4_t       | (VLEN / 8) * 8     | 8
+| __rvv_vint64m4x2_t     | vint64m4x2_t         | (VLEN / 8) * 8     | 8
+| __rvv_vuint64m4x2_t    | vuint64m4x2_t        | (VLEN / 8) * 8     | 8
+| __rvv_vfloat64m4x2_t   | vfloat64m4x2_t       | (VLEN / 8) * 8     | 8


### PR DESCRIPTION
The issue of Vector alignment is discussed in #347. It is mentioned that aligning to 128 bits might deliver better performance on some RISC-V cores, but this behavior could lead to considerable stack wastage on zve32 and zve64 cores. For instance, in order to ensure a vector value in the stack conforms to the ABI specification, we could potentially waste up to 96 bits per vector object in stack for zve32, and the performance difference isn't always evident across all core implementations.

Therefore, this proposal sets the alignment of vector types to element alignment, to avoid wasting a significant amount of stack space in zve32 and zve64 configurations. Also, since the ABI only specify the minimum alignment and doesn't limit the compiler from adopting higher alignment for specific CPUs.

Fix #347.