### PR TITLE
Support ILP32 on RV64 in psABI

### DIFF
--- a/introduction.adoc
+++ b/introduction.adoc
@@ -50,6 +50,10 @@ This specification uses the following terms and abbreviations:
 | LP64F             | Ratified
 | LP64D             | Ratified
 | LP64Q             | Ratified
+| RV64ILP32         | Draft
+| RV64ILP32F        | Draft
+| RV64ILP32D        | Draft
+| RV64ILP32Q        | Draft
 |===
 
 NOTE: ABI for big-endian is *NOT* included in this specification, we intend to

--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -493,10 +493,10 @@ LP64Q:: LP64 with hardware floating-point calling
 convention for ABI_FLEN=128 (i.e. <<ELFCLASS64,ELFCLASS64>> and
 <<EF_RISCV_FLOAT_ABI_QUAD,EF_RISCV_FLOAT_ABI_QUAD>>).
 
-The ILP32* ABIs are only compatible with RV32* ISAs, and the LP64* ABIs are
-only compatible with RV64* ISAs. A future version of this specification may
-define an ILP32 ABI for the RV64 ISA, but currently this is not a supported
-operating mode.
+The LP64* ABIs are only compatible with RV64* ISAs. The ILP32* are compatible
+with RV32* and RV64* ISAs.
+
+NOTE: RV64ILP32* ABIs are experimental.
 
 The *F ABIs require the *F ISA extension, the *D ABIs require the *D ISA
 extension, and the LP64Q ABI requires the Q ISA extension.
@@ -535,7 +535,7 @@ There are two conventions for C/{Cpp} type sizes and alignments.
 ILP32, ILP32F, ILP32D, and ILP32E:: Use the following type sizes and
 alignments (based on the ILP32 convention):
 +
-.C/{Cpp} type sizes and alignments for RV32
+.C/{Cpp} type sizes and alignments for ILP32
 [cols="4,>2,>3,4"]
 [width=60%]
 |===
@@ -561,7 +561,7 @@ alignments (based on the ILP32 convention):
 LP64, LP64F, LP64D, and LP64Q:: Use the following type sizes and
 alignments (based on the LP64 convention):
 +
-.C/{Cpp} type sizes and alignments for RV64
+.C/{Cpp} type sizes and alignments for LP64
 [cols="4,>2,>3,4"]
 [width=60%]
 |===

--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -449,6 +449,15 @@ The ILP32E calling convention is not compatible with ISAs that have registers
 that require load and store alignments of more than 32 bits. In particular, this
 calling convention must not be used with the D ISA extension.
 
+=== RV64ILP32* Calling Convention
+
+IMPORTANT: RV64ILP32* ABIs are experimental.
+
+The RV64ILP32* calling convention is designed to be usable with the RV64* ISA.
+These calling conventions are composed of the integer & floating-point & vector
+calling conventions. When passed in registers or on the stack, pointer scalars
+(32-bit), narrower than XLEN bits (64-bit), are sign-extended to XLEN bits.
+
 === Named ABIs
 
 This specification defines the following named ABIs:
@@ -491,6 +500,26 @@ convention for ABI_FLEN=64 (i.e. <<ELFCLASS64,ELFCLASS64>> and
 [[abi-lp64q]]
 LP64Q:: LP64 with hardware floating-point calling
 convention for ABI_FLEN=128 (i.e. <<ELFCLASS64,ELFCLASS64>> and
+<<EF_RISCV_FLOAT_ABI_QUAD,EF_RISCV_FLOAT_ABI_QUAD>>).
+
+[[abi-rv64ilp32]]
+RV64ILP32:: Integer calling-convention only, hardware
+floating-point calling convention is not used (i.e. <<ELFCLASS32,ELFCLASS32>> and
+<<EF_RISCV_FLOAT_ABI_SINGLE,EF_RISCV_FLOAT_ABI_SINGLE>>).
+
+[[abi-rv64ilp32f]]
+RV64ILP32F:: RV64ILP32 with hardware floating-point calling
+convention for ABI_FLEN=32 (i.e. <<ELFCLASS32,ELFCLASS32>> and
+<<EF_RISCV_FLOAT_ABI_SINGLE,EF_RISCV_FLOAT_ABI_SINGLE>>).
+
+[[abi-rv64ilp32d]]
+RV64ILP32D:: RV64ILP32 with hardware floating-point calling
+convention for ABI_FLEN=64 (i.e. <<ELFCLASS32,ELFCLASS32>> and
+<<EF_RISCV_FLOAT_ABI_DOUBLE,EF_RISCV_FLOAT_ABI_DOUBLE>>).
+
+[[abi-rv64ilp32q]]
+RV64ILP32Q:: RV64ILP32 with hardware floating-point calling
+convention for ABI_FLEN=128 (i.e. <<ELFCLASS32,ELFCLASS32>> and
 <<EF_RISCV_FLOAT_ABI_QUAD,EF_RISCV_FLOAT_ABI_QUAD>>).
 
 The LP64* ABIs are only compatible with RV64* ISAs. The ILP32* are compatible

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -247,8 +247,8 @@ header fields; any fields not listed in this section have no RISC-V-specific
 values.
 
 e_ident::
-  EI_CLASS::: Specifies the base ISA, either RV32 or RV64.
-  Linking RV32 and RV64 code together is not supported.
+  EI_CLASS::: Specifies the ABIs, either ILP32*, LP64* or RV64ILP32*.
+  Linking different ABIs' code together is not supported.
 +
 --
 [horizontal]
@@ -277,12 +277,12 @@ below.
 +
 [[e-flags-layout]]
 .Layout of e_flags
-[cols="1,2,1,1,3,5"]
+[cols="1,2,1,1,1,3,5"]
 [width=80%]
 |===
-| Bit 0 | Bits 1 - 2 | Bit 3 | Bit 4 | Bits 5 - 23 | Bits 24 - 31
+| Bit 0 | Bits 1 - 2 | Bit 3 | Bit 4 | Bit 5     | Bits 6 - 23 | Bits 24 - 31
 
-| RVC   | Float ABI  | RVE   | TSO   | *Reserved*  | *Non-standard extensions*
+| RVC   | Float ABI  | RVE   | TSO   | RV64ILP32 | *Reserved*  | *Non-standard extensions*
 |===
 
 +
@@ -320,6 +320,11 @@ below.
   EF_RISCV_TSO (0x0010)::: This bit is set when the binary requires the RVTSO
   memory consistency model.
 
+  EF_RISCV_RV64ILP32 (0x0020)::: This bit is set when the binary requires the
+  RV64ILP32* ABIs on RV64* ISAs.
+
+NOTE: RV64ILP32* ABIs are experimental.
+
 Until such a time that the *Reserved* bits (0x00ffffe0) are allocated by future
 versions of this specification, they shall not be set by standard software.
 Non-standard extensions are free to use bits 24-31 for any purpose. This may
@@ -354,6 +359,9 @@ raise an error.
 
   TSO::: Input files can have different values for the TSO field; the linker
   should set this field if any of the input objects have the TSO field set.
+
+  RV64ILP32::: Linker should report errors if object files of different value
+  for RV64ILP32 field.
 
 NOTE: The static linker may ignore the compatibility checks if all fields in the
 `e_flags` are zero and all sections in the input file are non-executable

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -101,6 +101,8 @@ NOTE: Although the generated code is technically position independent, it's not
 suitable for ELF shared libraries due to differing symbol interposition rules;
 for that, please use the medium position independent code model below.
 
+NOTE: The address space of RV64ILP32* ABIs is not continuous in the middle.
+
 === Medium position independent code model
 
 This model is similar to the medium any code model, but uses the


### PR DESCRIPTION
This pull request adds a new e_flags X32. It occupies the sixth bit of e_flags layout.

We have initially implemented rv64 ilp32 on the gnu toolchain and kernel.
Details in this [link](https://lore.kernel.org/linux-riscv/20230518131013.3366406-1-guoren@kernel.org/).

@guoren83 @palmer-dabbelt  @kito-cheng 