### PR TITLE
Deprecate PT_RISCV_ATTRIBUTES

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1092,22 +1092,6 @@ The defined processor-specific section types are listed in <<rv-section-type>>.
 +++.riscv.jvt+++ is a linker-created section to store table jump
 target addresses. The minimum alignment of this section is 64 bytes.
 
-=== Program Header Table
-
-The defined processor-specific segment types are listed in <<rv-seg-type>>.
-
-[[rv-seg-type]]
-.RISC-V-specific segment types
-[cols="3,2,3"]
-[width=80%]
-|===
-| Name                 | Value       | Meaning
-
-| PT_RISCV_ATTRIBUTES  | 0x70000003  | RISC-V ELF attribute section.
-|===
-
-`PT_RISCV_ATTRIBUTES` describes the location of RISC-V ELF attribute section.
-
 === Note Sections
 
 There are no RISC-V specific definitions relating to ELF note sections.

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1092,6 +1092,26 @@ The defined processor-specific section types are listed in <<rv-section-type>>.
 +++.riscv.jvt+++ is a linker-created section to store table jump
 target addresses. The minimum alignment of this section is 64 bytes.
 
+=== Program Header Table
+
+The defined processor-specific segment types are listed in <<rv-seg-type>>.
+
+[[rv-seg-type]]
+.RISC-V-specific segment types
+[cols="3,2,3"]
+[width=80%]
+|===
+| Name                 | Value       | Meaning
+
+| PT_RISCV_ATTRIBUTES  | 0x70000003  | RISC-V ELF attribute section.
+|===
+
+`PT_RISCV_ATTRIBUTES` describes the location of RISC-V ELF attribute section.
+
+WARNING: `PT_RISCV_ATTRIBUTES` is deprecated. The build attributes section does
+not contain the `SHF_ALLOC` flag. Dynamic loaders cannot assume that the region
+described by `PT_RISCV_ATTRIBUTES` is present.
+
 === Note Sections
 
 There are no RISC-V specific definitions relating to ELF note sections.


### PR DESCRIPTION
#71 added a PT_RISCV_ATTRIBUTES segment to contain the SHT_RISCV_ATTRIBUTES section. The SHT_RISCV_ATTRIBUTES section does not have the SHF_ALLOC flag and is therefore not in a PT_LOAD segment. Dynamic loaders cannot assume the PT_RISCV_ATTRIBUTES part is present (it may happen to be mapped due to page alignment, but there is no guarantee).

To the best of my knowledge, PT_RISCV_ATTRIBUTES is the only open-source usage of a segment that contains a non-SHF_ALLOC section.

I think the existence of PT_RISCV_ATTRIBUTES just complicates analysis tools and binary manipulation tools like strip. E.g. if the SHT_RISCV_ATTRIBUTES section is removed, what should we do with PT_RISCV_ATTRIBUTES?

I think we should remove PT_RISCV_ATTRIBUTES, but ensure that the program header type is not reused by a future program header type.