### PR TITLE
Add large code model information.

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -130,16 +130,11 @@ This model is similar to the medium any code model, but uses the
 The `large` code model allows the code to address the whole RV64 address space.
 Thus, this model is only available for RV64. By putting object addresses
 into literal pools, a 64-bit address literal can be loaded from the pool.
-This model also changes the function call patterns. An external function
-address must be loaded from a literal pool entry, and use `jalr` to jump to
-the target function.
 
 NOTE: Because calculating the pool entry address must use `aupic` and
 `addi` or `ld`, each pool entry has to be located within the range
 between -2GiB and +2GiB from its access intructions.  In general, the pool
 is appeneded in .text section or put into .rodata section.
-
-NOTE: Large code model is disallowed to be used with PIC code model.
 
 [,asm]
 ----
@@ -148,8 +143,20 @@ NOTE: Large code model is disallowed to be used with PIC code model.
          .LCPI0:
            .dword symbol
 .Ltmp0:  auipc   a0, %pcrel_hi(.LCPI0)
-         ld      a0, %pcrel_lo(.Ltmp0)(10)
+         ld      a0, %pcrel_lo(.Ltmp0)(a0)
+----
 
+This model also changes the function call patterns. An external function
+address must be loaded from a literal pool entry, and use `jalr` to jump to
+the target function.
+
+
+NOTE: Same as getting address of symbol, each pool entry has to be located
+within the range between -2GiB and +2GiB from its access intructions.  The
+function call can reach the whole 64-bit address space.
+
+[,asm]
+----
          # Function call
          # Literal pool
          .LCPI1:
@@ -157,8 +164,12 @@ NOTE: Large code model is disallowed to be used with PIC code model.
 .Ltmp1:  auipc   a0, %pcrel_hi(.LCPI1)
          ld      a0, %pcrel_lo(.Ltmp1)(a0)
          jalr    a0
-
 ----
+
+NOTE: Large code model is disallowed to be used with PIC code model.
+
+NOTE: There will be more different code generation strategies for different
+usage purposes in the future.
 
 == Dynamic Linking
 

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -156,6 +156,11 @@ NOTE: Same as getting address of symbol, each pool entry has to be located
 within the range between -2GiB and +2GiB from its access intructions.  The
 function call can reach the whole 64-bit address space.
 
+NOTE: The code generation of function call may be changed after the range
+extension thunk is implemented. The compiler can emit `call` directly,
+and leave the model variation to the linker which could decide to jump
+via the literal pool or not.
+
 [,asm]
 ----
          # Function call

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -142,6 +142,7 @@ is appeneded in .text section or put into .rodata section.
          # Literal pool
 .LCPI0:
          .8byte symbol
+	 ...
 .Ltmp0:  auipc   a0, %pcrel_hi(.LCPI0)
          ld      a0, %pcrel_lo(.Ltmp0)(a0)
 ----
@@ -161,6 +162,7 @@ function call can reach the whole 64-bit address space.
          # Literal pool
 .LCPI1:
          .8byte function
+	 ...
 .Ltmp1:  auipc   a0, %pcrel_hi(.LCPI1)
          ld      a0, %pcrel_lo(.Ltmp1)(a0)
          jalr    a0

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -140,8 +140,8 @@ is appeneded in .text section or put into .rodata section.
 ----
          # Get address of a symbol
          # Literal pool
-         .LCPI0:
-           .dword symbol
+.LCPI0:
+         .8byte symbol
 .Ltmp0:  auipc   a0, %pcrel_hi(.LCPI0)
          ld      a0, %pcrel_lo(.Ltmp0)(a0)
 ----
@@ -159,8 +159,8 @@ function call can reach the whole 64-bit address space.
 ----
          # Function call
          # Literal pool
-         .LCPI1:
-           .dword function
+.LCPI1:
+         .8byte function
 .Ltmp1:  auipc   a0, %pcrel_hi(.LCPI1)
          ld      a0, %pcrel_lo(.Ltmp1)(a0)
          jalr    a0

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -125,6 +125,41 @@ This model is similar to the medium any code model, but uses the
          l[w|d] a0, a0, %pcrel_lo(.Ltmp3)
 ----
 
+=== Large code model
+
+The `large` code model allows the code to address the whole RV64 address space.
+Thus, this model is only available for RV64. By putting object addresses
+into literal pools, a 64-bit address literal can be loaded from the pool.
+This model also changes the function call patterns. An external function
+address must be loaded from a literal pool entry, and use `jalr` to jump to
+the target function.
+
+NOTE: Because calculating the pool entry address must use `aupic` and
+`addi` or `ld`, each pool entry has to be located within the range
+between -2GiB and +2GiB from its access intructions.  In general, the pool
+is appeneded in .text section or put into .rodata section.
+
+NOTE: Large code model is disallowed to be used with PIC code model.
+
+[,asm]
+----
+         # Get address of a symbol
+         # Literal pool
+         .LCPI0:
+           .dword symbol
+.Ltmp0:  auipc   a0, %pcrel_hi(.LCPI0)
+         ld      a0, %pcrel_lo(.Ltmp0)(10)
+
+         # Function call
+         # Literal pool
+         .LCPI1:
+           .dword function
+.Ltmp1:  auipc   a0, %pcrel_hi(.LCPI1)
+         ld      a0, %pcrel_lo(.Ltmp1)(a0)
+         jalr    a0
+
+----
+
 == Dynamic Linking
 
 Any functions that use registers in a way that is incompatible with


### PR DESCRIPTION
Hi,

This PR add description about large code model.
I was wondering if we need `large+fpic` model.
In general, position independant code model puts external symbol addresses into the GOT table.
Is there any case that we have to layout GOT table far away from code over +-2GB?