### PR TITLE
Add R_RISCV_ALIGN_DOWN

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -452,7 +452,9 @@ Description:: Additional information about the relocation
                                             <| S + A
 .2+| 61      .2+| SUB_ULEB128   .2+| Static  | _ULEB128_         .2+| Local label subtraction <<uleb128-note,*note>>
                                             <| V - S - A
-.2+| 62-191  .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
+.2+| 62      .2+| ALIGN_DOWN    .2+| Static  |                   .2+| Alignment statement. The addend indicates the number of bytes occupied by `nop` instructions at the relocation offset. The alignment boundary is specified by the addend rounded down to the next power of two.
+                                            <|
+.2+| 63-191  .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
                                             <|
 .2+| 192-255 .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for nonstandard ABI extensions
                                             <|


### PR DESCRIPTION
We're in the process of stumbling into another round of these bugs related to insufficient alignment bytes.  The idea of adding another alignment reloation that rounds down has come up a few times, but I don't remember if anyone's actually written the spec.  So here's one.