### PR TITLE
Add GP-relative relocations

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -428,7 +428,13 @@ Description:: Additional information about the relocation
                                             <| S + A - P
 .2+| 46      .2+| RVC_LUI       .2+| Static  | _CI-Type_         .2+| High 6 bits of 18-bit absolute address
                                             <| S + A
-.2+| 47-50   .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
+.2+| 47      .2+| GPREL_LO12_I  .2+| Static  | _I-type_          .2+| Low 12 bits of a 32-bit GP-relative address, `%gprel_lo(symbol)`
+                                            <| S + A - GP
+.2+| 48      .2+| GPREL_LO12_S  .2+| Static  | _S-Type_          .2+| Low 12 bits of a 32-bit GP-relative address, `%gprel_lo(symbol)`
+                                            <| S + A - GP
+.2+| 49      .2+| GPREL_HI20    .2+| Static  | _U-Type_          .2+| High 20 bits of a 32-bit GP-relative address, `%gprel_hi(symbol)`
+                                            <| S + A - GP
+.2+| 50      .2+| *Reserved*                          .2+| -        |                  .2+| Reserved for future standard use
                                             <|
 .2+| 51      .2+| RELAX         .2+| Static  |                   .2+| Instruction can be relaxed, paired with a normal relocation at the same address
                                             <|


### PR DESCRIPTION
Following-up on @kito-cheng's suggestion to add the ePIC [proposal](https://github.com/riscv-non-isa/riscv-elf-psabi-doc/pull/343) content to the existing psABI documents, this initial PR adds the GP-relative relocations. These GP-relocations should be useful for purposes besides ePIC (e.g. see previous proposals of the compact/large code models).

For ease of review, I will make a separate PR to add `R_RISCV_GPREL_ADD`, used for relaxation purposes, unless you prefer otherwise.

I'm not sure these GP relocations merit a GP-relative addressing section, such as the existing "PC-Relative Symbol Addresses", as there aren't the same kind of complications to comment on. If you feel it's needed, I will add one to this PR.