### PR TITLE
Allocate e_flags for landing pad and shadow stack

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -194,9 +194,9 @@ below.
 [cols="1,2,1,1,3,5"]
 [width=80%]
 |===
-| Bit 0 | Bits 1 - 2 | Bit 3 | Bit 4 | Bits 5 - 23 | Bits 24 - 31
+| Bit 0 | Bits 1 - 2 | Bit 3 | Bit 4 | Bit 5  | Bit 6  | Bits 7 - 23 | Bits 24 - 31
 
-| RVC   | Float ABI  | RVE   | TSO   | *Reserved*  | *Non-standard extensions*
+| RVC   | Float ABI  | RVE   | TSO   | CFI_LP | CFI_SS | *Reserved*  | *Non-standard extensions*
 |===
 
 +
@@ -233,6 +233,10 @@ below.
 
   EF_RISCV_TSO (0x0010)::: This bit is set when the binary requires the RVTSO
   memory consistency model.
+  EF_RISCV_CFI_LP (0x0020)::: This bit is set when the binary has build with
+  landing pad.
+  EF_RISCV_CFI_SS (0x0040)::: This bit is set when the binary requires the Zimop
+  or Zicfiss extension.
 
 Until such a time that the *Reserved* bits (0x00ffffe0) are allocated by future
 versions of this specification, they shall not be set by standard software.


### PR DESCRIPTION
We didn't allocate bit for individual extension generally, but landing pad and (hardware) shadow stack will require dynamic linker to check all dependent DSOs, so it worth to allocate e_flags to those two speical extension.

`EF_RISCV_CFI_LP` means this binary has build with landing pad, but *NOT* required the platform has support Zicfilp extension, since Zicfilp is using hint instruction, so it can be safely execute without Zicfilp, dynamic linker will check all dependent DSOs has set this flag, and enable the landing pad checking if all DSOs has support.

`EF_RISCV_CFI_SS` means this binary requires the Zimop or Zicfiss extension, which is different than `EF_RISCV_CFI_LP`, because it's *NOT* using hint instruction, dynamic linker will check all dependent DSOs has set this flag, and enable the shadow stack if all DSOs has support, otherwise enable Zimop mode only.

NOTE: `Zicfiss` and `Zicfilp` are not frozen yet, this PR created for asking feedback and implement toolchain PoC