### PR TITLE
Specify the alignment and size for array

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -493,6 +493,14 @@ The alignment of `max_align_t` is 16.
 Structs and unions are aligned to the alignment of their most strictly aligned
 member. The size of any object is a multiple of its alignment.
 
+=== Array
+
+The alignment requirement for an array shall be equivalent to the alignment
+requirement of its elemental type.
+
+The size of an array is determined by multiplying the size of its
+elemental type by the total number of elements within the array.
+
 === C/{Cpp} type representations
 
 `char` is unsigned.


### PR DESCRIPTION
After I reviewing the calling convention part, I found we missed the alignment and size for array, fortunately it's both open source compilers are implement the same, so just document that down.