### PR TITLE
Specify the Calling Convention for Fixed-Length Vectors

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -183,6 +183,9 @@ Aggregates larger than 2×XLEN bits are passed by reference and are replaced in
 the argument list with the address, as are {Cpp} aggregates with nontrivial copy
 constructors, destructors, or vtables.
 
+Fixed length vector are passed by reference and are replaced in the argument
+list with the address.
+
 Empty structs or union arguments or return values are ignored by C compilers
 which support them as a non-standard extension.  This is not the case for {Cpp},
 which requires them to be sized types.
@@ -492,6 +495,18 @@ The alignment of `max_align_t` is 16.
 
 Structs and unions are aligned to the alignment of their most strictly aligned
 member. The size of any object is a multiple of its alignment.
+
+=== Fixed length vector
+
+Various compilers has support fixed length vector, one of example is GCC and
+clang both support declare type with `__attribute__((vector_size(N))`, where `N`
+is a postive number larger than zero.
+
+The alignment requirement for the fixed length vector shall be equivalent to the
+alignment requirement of its elemental type.
+
+The size of the is determined by multiplying the size of its
+elemental type by the total number of elements within the vector.
 
 === C/{Cpp} type representations
 


### PR DESCRIPTION
Previously, there was no mention of fixed-length vectors in the psABI. Unfortunately, GCC and Clang have implemented support for fixed-length vectors differently for a long time. We should address this soon, as the RISC-V ecosystem is expanding and optimizing programs with fixed-length vectors, especially with the upcoming vector extension, is becoming more common.

There are two options for passing arguments with fixed-length vectors:

1. The first is passing as an array type, which always involves passing by reference.
2. The second is passing as a struct type. This may involve passing the value by reference, integer registers, or floating-point registers, depending on the size of the fixed-length vector, similar to a struct.

GCC uses the first method, while Clang uses the second.

The drawback of the second option is the extra overhead required when generating code with vector instructions.

Consider the following code as an example. GCC passes `a` and `b` by reference, using the `a0` and `a1` registers to pass their addresses. Clang, however, passes `a` and `b` through integer registers: using `a0` and `a1` to pass `a`; `a2` and `a3` to pass `b`.

```c
typedef int int32x4_t __attribute__((vector_size(16)));

int32x4_t foo(int32x4_t a, int32x4_t b) {
  int32x4_t ret = a + b;
  return ret;
}
```

The code generation with vector extension for pass-by-reference is straightforward: load the value from the pointer, perform the operation, and then store the result.

```
_Z3fooDv4_iS_:
        vsetivli        zero,4,e32,m1,ta,ma
        vle32.v v1,0(a1)
        vle32.v v2,0(a2)
        vadd.vv v1,v1,v2
        vse32.v v1,0(a0)
        ret
```

However, the code generation with the vector extension for the struct approach is quite complicated. It might use `vslide1down.vx` or `vmv.v.s` to move data between integer and vector registers, which can generally result in poor performance.

```
_Z3fooDv4_iS_:
        vsetivli        zero, 2, e64, m1, ta, ma
        vslide1down.vx  v8, v8, a0
        vslide1down.vx  v8, v8, a1
        vslide1down.vx  v9, v8, a2
        vslide1down.vx  v9, v9, a3
        vsetivli        zero, 4, e32, m1, ta, ma
        vadd.vv v8, v9, v8
        vsetivli        zero, 1, e64, m1, ta, ma
        vmv.x.s a0, v8
        vslidedown.vi   v8, v8, 1
        vmv.x.s a1, v8
        ret
```

Therefore, this PR proposes that fixed-length vectors should always be passed by reference.

We also plan to submit another proposal to address the issue of passing fixed-length vectors via vector registers.