### PR TITLE
Clarify ULEB128 note

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -484,10 +484,11 @@ assembler syntax, including that of the relocations, is described in the
 _RISC-V Assembly Programmer's Manual_ <<rv-asm>>.
 
 [[uleb128-note]]
-NOTE: The assembler must allocate enough space to accommodate ULEB128 data for
-`R_RISCV_SET_ULEB128` and `R_RISCV_SUB_ULEB128` relocations. This can be
-achieved either by padding with zeroes to fill up to the XLEN-bits boundary
-or by filling the precomputed result into the relocation location.
+NOTE: The assembler must allocate sufficient space to accommodate the final
+value for the `R_RISCV_SET_ULEB128` and `R_RISCV_SUB_ULEB128` relocation pair
+and fill the space with a single ULEB128-encoded value.
+This is achieved by prepending the redundant `0x80` byte as necessary.
+The linker must not alter the length of the ULEB128-encoded value.
 
 ==== Calculation Symbols
 


### PR DESCRIPTION
Previously, it is not very clear what the linker does for `R_RISCV_{SET,SUB}_ULEB128` relocations. Based on the discussion at https://github.com/riscv-non-isa/riscv-elf-psabi-doc/pull/413, the intended specification appears to be as follows:

 - the assembler allocates enough space for the final computed value for the `R_RISCV_{SET,SUB}_ULEB128` relocation pair and fills the space with a ULEB128 value, which may be redundantly encoded
 - the linker reads an existing ULEB128 value and overwrites it, without changing the length of the existing ULEB128 value

This change serves to clarify the above points.