### PR TITLE
Add program property and PLT for CFI extension

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -762,7 +762,7 @@ The first entry in the PLT occupies two 16 byte entries for the default PLT styl
 [,asm]
 ----
 1:  auipc  t2, %pcrel_hi(.got.plt)
-    sub    t1, t1, t3               # shifted .got.plt offset + hdr size + 12 
+    sub    t1, t1, t3               # shifted .got.plt offset + hdr size + 12
     l[w|d] t3, %pcrel_lo(1b)(t2)    # _dl_runtime_resolve
     addi   t1, t1, -(hdr size + 12) # shifted .got.plt offset
     addi   t0, t2, %pcrel_lo(1b)    # &.got.plt
@@ -771,7 +771,7 @@ The first entry in the PLT occupies two 16 byte entries for the default PLT styl
     jr     t3
 ----
 
-And occupies two 16 byte entries for the unlabeled landing pad PLT style:
+And occupies two 16 byte entries for the landing pad PLT style:
 
 [,asm]
 ----
@@ -1525,7 +1525,7 @@ Description:: Additional information about the program property type.
 each bit indicating a feature that the object file is compatible with. The
 linker should perform a bitwise AND operation when merging different objects.
 
-The value of `GNU_PROPERTY_RISCV_FEATURE_1_AND` is defined in <<rv-prog-prop-type>>.
+The `pr_type` value of `GNU_PROPERTY_RISCV_FEATURE_1_AND` is `0xc0000000`.
 
 [%autowidth]
 |===
@@ -1538,7 +1538,7 @@ The value of `GNU_PROPERTY_RISCV_FEATURE_1_AND` is defined in <<rv-prog-prop-typ
 executable sections are built to be compatible with the landing pad mechanism
 provided by the Zicfilp extension in the unlabeled scheme: Executables and
 shared libraries with this bit set are required to generate PLTs in the
-unlabeled landing pad PLT style, and all of the labels of lpad instructions are
+landing pad PLT style, and all of the labels of lpad instructions are
 set to 0, i.e. unlabeled.
 See <<Tool Requirements for Generating Landing Pad Instruction>> for more details.
 
@@ -1561,8 +1561,7 @@ instruction with a compatible label value. Indirect branches may originate from:
 
 * Static linkers when generating PLT entries.
 
-* Other executables and shared libraries via calls through PLT entries or
-  function pointers.
+* Other executables and shared libraries via calls through function pointers.
 
 It is desirable to minimize the number of landing pad instructions to limit the
 number of indirect branch destinations within the program. The following tool

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -777,6 +777,7 @@ And occupies three 16 byte entries for the simple landing pad PLT style:
     jr     t3
     nop
     nop
+    nop
 ----
 
 Subsequent function entry stubs in the PLT take up 16 bytes.

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1484,7 +1484,7 @@ a different features.
 sections are built to be compatible with the landing pad mechanism provided by
 the `Zicfilp` extension. An executable or shared library with this bit set is
 required to generate PLTs with the landing pad (`lpad`) instruction, and all
-label are set to `1`.
+label are set to `0`.
 
 `GNU_PROPERTY_RISCV_FEATURE_1_CFI_SS`: This bit indicate that all executable
 sections are built to be compatible with the shadow stack mechanism provided by

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1531,6 +1531,7 @@ provided by the Zicfilp extension in the unlabeled scheme: Executables and
 shared libraries with this bit set are required to generate PLTs in the
 unlabeled landing pad PLT style, and all of the labels of lpad instructions are
 set to 0, i.e. unlabeled.
+See <<Tool Requirements for Generating Landing Pad Instruction>> for more details.
 
 `GNU_PROPERTY_RISCV_FEATURE_1_CFI_SS`: This bit indicates that all executable
 sections are built to be compatible with the shadow stack mechanism provided by
@@ -1539,6 +1540,39 @@ set requires the execution environment to provide either the `Zicfiss` extension
 or the `Zimop` extension. When the executable or shared library is compiled with
 compressed instructions then loading it with this bit set requires the execution
 environment to provide the `Zicfiss` extension or the `Zcmop` extensions.
+
+=== Tool Requirements for Generating Landing Pad Instructions
+
+For an executable or shared library to set the GNU property
+`GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_UNLABELED`, every indirect branch targeting
+a location guarded by landing pads must point to a landing pad (`lpad`)
+instruction with a compatible label value. Indirect branches may originate from:
+
+* Relocatable object producers, such as a compiler or assembler.
+
+* Static linkers when generating PLT entries.
+
+* Other executables and shared libraries via calls through PLT entries or
+  function pointers.
+
+It is desirable to minimize the number of landing pad instructions to limit the
+number of indirect branch destinations within the program. The following tool
+requirements determine which tool is responsible for inserting landing pad
+instructions, allowing tools to omit landing pad instructions if it can be
+proven that there are no indirect branches targeting the location.
+
+A relocatable object producer is required to insert a landing pad instruction at
+the target of an indirect branch originating from within the same relocatable
+object.
+
+A relocatable object producer must insert a landing pad instruction at any
+location whose address escapes the relocatable object. This includes all symbols
+that can be exported into the dynamic symbol table by a static linker.
+
+A static linker is required to generate PLT entries with appropriate landing pad
+instructions. During linker relaxation, a static linker may remove unnecessary
+landing pad instructions if it can prove that there are no indirect branches
+targeting the corresponding location.
 
 === Mapping Symbol
 

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -727,9 +727,9 @@ The PLT (Procedure Linkage Table) exists to allow function calls between
 dynamically linked shared objects. Each dynamic object has its own
 GOT (Global Offset Table) and PLT (Procedure Linkage Table).
 
-RISC-V has defined several PLT styles, which used for different situation,
-the default PLT sytle should be used if the program is not met the condition for
-using all other PLT sytle.
+RISC-V defines several PLT styles, which are used in different situations.
+The default PLT style should be used if the program does not meet the conditions
+for using all other PLT sytles.
 
 [[plt-style]]
 .PLT styles
@@ -763,11 +763,11 @@ The first entry in the PLT occupies two 16 byte entries for the default PLT styl
     jr     t3
 ----
 
-And occupies three 16 byte entries for the simple landing pad PLT style:
+And occupies three 16 byte entries for the unlabeled landing pad PLT style:
 [,asm]
 ----
-1:  lpad 0
-    auipc  t2, %pcrel_hi(.got.plt)
+    lpad 0
+1:  auipc  t2, %pcrel_hi(.got.plt)
     sub    t1, t1, t3               # shifted .got.plt offset + hdr size + 16
     l[w|d] t3, %pcrel_lo(1b)(t2)    # _dl_runtime_resolve
     addi   t1, t1, -(hdr size + 16) # shifted .got.plt offset
@@ -794,11 +794,11 @@ The code sequences of the PLT entry for the default PLT style:
     nop
 ----
 
-The code sequences of the PLT entry for the the simple landing pad PLT style:
+The code sequences of the PLT entry for the unlabeled landing pad PLT style:
 [,asm]
 ----
-1:  lpad 0
-    auipc   t3, %pcrel_hi(function@.got.plt)
+    lpad 0
+1:  auipc   t3, %pcrel_hi(function@.got.plt)
     l[w|d]  t3, %pcrel_lo(1b)(t3)
     jalr    t1, t3
 ----
@@ -1492,9 +1492,10 @@ meaning of each column is given below:
 
 Name:: The name of the program property type, omitting the prefix of `GNU_PROPERTY_RISCV_`.
 
-Value:: The type value for the program property type.
+Value:: The `pr_type` value for the program property type.
 
-Size:: The data type size hold within this program property type.
+Size:: The size (`pr_datasz`) of data type held within this program property
+       type.
 
 Description:: Additional information about the program property type.
 
@@ -1511,7 +1512,6 @@ Description:: Additional information about the program property type.
 
 ==== GNU_PROPERTY_RISCV_FEATURE_1_AND
 
-
 `GNU_PROPERTY_RISCV_FEATURE_1_AND` describes a set of features, where each bit
 represents a different feature. The linker should perform a bitwise AND
 operation when merging different objects.
@@ -1523,20 +1523,20 @@ operation when merging different objects.
 |   1 | GNU_PROPERTY_RISCV_FEATURE_1_CFI_SS
 |===
 
-`GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_UNLABELED` This bit indicate that all
+`GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_UNLABELED`: This bit indicates that all
 executable sections are built to be compatible with the landing pad mechanism
-provided by the `Zicfilp` extension. An executable or shared library with this
-bit set is required to generate PLTs with the landing pad (`lpad`) instruction,
-and all label are set to `0`.
+provided by the Zicfilp extension in the unlabeled scheme: Executables and
+shared libraries with this bit set are required to generate PLTs in the
+unlabeled landing pad PLT style, and all of the labels of lpad instructions are
+set to 0, i.e. unlabeled.
 
-`GNU_PROPERTY_RISCV_FEATURE_1_CFI_SS`: This bit indicate that all executable
+`GNU_PROPERTY_RISCV_FEATURE_1_CFI_SS`: This bit indicates that all executable
 sections are built to be compatible with the shadow stack mechanism provided by
 the `Zicfiss` extension. Loading an executable or shared library with this bit
 set requires the execution environment to provide either the `Zicfiss` extension
 or the `Zimop` extension. When the executable or shared library is compiled with
-compressed instructions then loading an executable with this bit set requires
-the execution environment to provide the `Zicfiss` extension or to provide both
-the `Zcmop` and `Zimop` extensions.
+compressed instructions then loading it with this bit set requires the execution
+environment to provide the `Zicfiss` extension or the `Zimop` extensions.
 
 === Mapping Symbol
 

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1536,7 +1536,7 @@ the `Zicfiss` extension. Loading an executable or shared library with this bit
 set requires the execution environment to provide either the `Zicfiss` extension
 or the `Zimop` extension. When the executable or shared library is compiled with
 compressed instructions then loading it with this bit set requires the execution
-environment to provide the `Zicfiss` extension or the `Zimop` extensions.
+environment to provide the `Zicfiss` extension or the `Zcmop` extensions.
 
 === Mapping Symbol
 

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1445,14 +1445,27 @@ that a linker or runtime loader needs to check for compatibility.
 The linker should ignore and discard unknown bits in program properties, and
 issue warnings or errors.
 
+<<rv-prog-prop-type>> provides details of the RISC-V ELF program property; the
+meaning of each column is given below:
+
+
+Name:: The name of the program property type, omitting the prefix of `GNU_PROPERTY_RISCV_`.
+
+Value:: The type value for the program property type.
+
+Size:: The data type size hold within this program property type.
+
+Description:: Additional information about the program property type.
+
+
 [[rv-prog-prop-type]]
 .RISC-V-specific program property types
-[cols="3,2,2,3"]
-[width=80%]
+[cols="3,3,2,5"]
+[width=100%]
 |===
-| Name                              | Value      | Size    | Meaning
+| Name           | Value      | Size    | Description
 
-| GNU_PROPERTY_RISCV_FEATURE_1_AND  | 0xc0000000 | 4-bytes | RISC-V processor-specific features used in program.
+| FEATURE_1_AND  | 0xc0000000 | 4-bytes | RISC-V processor-specific features used in program.
 |===
 
 ==== GNU_PROPERTY_RISCV_FEATURE_1_AND

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -736,8 +736,8 @@ for using any of the other PLT sytles.
 [cols="1,2"]
 [width=70%]
 |===
-| Default PLT               | -
-| Unlabeled landing pad PLT | Must use this PLT style when `GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_UNLABELED` is set.
+| Default PLT     | -
+| Landing pad PLT | Must use this PLT style when `GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_UNLABELED` is set.
 |===
 
 The first entry of a shared object PLT is a special entry that calls
@@ -749,12 +749,20 @@ dynamic linker before the executable is started. Lazy resolution of GOT
 entries is intended to speed up program loading by deferring symbol
 resolution to the first time the function is called.
 
+Landing pad PLT can't be used with lazy binding.
+
+NOTE: Landing pads are designed for use with Control-Flow Integrity (CFI).
+Lazy binding may delay resolution of indirect branches until runtime, potentially
+allowing attackers to hijack control flow before CFI protections are fully
+enforced. Therefore, lazy binding is considered unsafe in conjunction with
+landing pad-based PLTs.
+
 The first entry in the PLT occupies two 16 byte entries for the default PLT style:
 
 [,asm]
 ----
 1:  auipc  t2, %pcrel_hi(.got.plt)
-    sub    t1, t1, t3               # shifted .got.plt offset + hdr size + 12
+    sub    t1, t1, t3               # shifted .got.plt offset + hdr size + 12 
     l[w|d] t3, %pcrel_lo(1b)(t2)    # _dl_runtime_resolve
     addi   t1, t1, -(hdr size + 12) # shifted .got.plt offset
     addi   t0, t2, %pcrel_lo(1b)    # &.got.plt
@@ -763,22 +771,23 @@ The first entry in the PLT occupies two 16 byte entries for the default PLT styl
     jr     t3
 ----
 
-And occupies three 16 byte entries for the unlabeled landing pad PLT style:
+And occupies two 16 byte entries for the unlabeled landing pad PLT style:
+
 [,asm]
 ----
-    lpad 0
-1:  auipc  t2, %pcrel_hi(.got.plt)
-    sub    t1, t1, t3               # shifted .got.plt offset + hdr size + 16
-    l[w|d] t3, %pcrel_lo(1b)(t2)    # _dl_runtime_resolve
+1:  auipc  t3, %pcrel_hi(.got.plt)
+    sub    t1, t1, t2               # shifted .got.plt offset + hdr size + 16
+    l[w|d] t2, %pcrel_lo(1b)(t3)    # _dl_runtime_resolve
     addi   t1, t1, -(hdr size + 16) # shifted .got.plt offset
-    addi   t0, t2, %pcrel_lo(1b)    # &.got.plt
+    addi   t0, t3, %pcrel_lo(1b)    # &.got.plt
     srli   t1, t1, log2(16/PTRSIZE) # .got.plt offset
     l[w|d] t0, PTRSIZE(t0)          # link map
-    jr     t3
-    nop
-    nop
-    nop
+    jr     t2
 ----
+
+NOTE: Although lazy binding is prohibited for landing pad PLTs, the PLT
+header is still retained so that features implemented by the C library, such
+as LD_AUDIT and LD_PROFILE in glibc, continue to function as intended.
 
 Subsequent function entry stubs in the PLT take up 16 bytes.
 On the first call to a function, the entry redirects to the first PLT entry
@@ -794,13 +803,13 @@ The code sequences of the PLT entry for the default PLT style:
     nop
 ----
 
-The code sequences of the PLT entry for the unlabeled landing pad PLT style:
+The code sequences of the PLT entry for the landing pad PLT style:
 [,asm]
 ----
     lpad 0
-1:  auipc   t3, %pcrel_hi(function@.got.plt)
-    l[w|d]  t3, %pcrel_lo(1b)(t3)
-    jalr    t1, t3
+1:  auipc   t2, %pcrel_hi(function@.got.plt)
+    l[w|d]  t2, %pcrel_lo(1b)(t2)
+    jalr    t1, t2
 ----
 
 ==== Procedure Calls

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -727,6 +727,19 @@ The PLT (Procedure Linkage Table) exists to allow function calls between
 dynamically linked shared objects. Each dynamic object has its own
 GOT (Global Offset Table) and PLT (Procedure Linkage Table).
 
+RISC-V has defined several PLT styles, which used for different situation,
+the default PLT sytle should be used if the program is not met the condition for
+using all other PLT sytle.
+
+[[plt-style]]
+.PLT styles
+[cols="1,2"]
+[width=70%]
+|===
+| Default PLT                  | -
+| Simple landing pad PLT | Must use this PLT style when `GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_SIMPLE` is set.
+|===
+
 The first entry of a shared object PLT is a special entry that calls
 `_dl_runtime_resolve` to resolve the GOT offset for the called function.
 The `_dl_runtime_resolve` function in the dynamic loader resolves the
@@ -734,8 +747,9 @@ GOT offsets lazily on the first call to any function, except when
 `LD_BIND_NOW` is set in which case the GOT entries are populated by the
 dynamic linker before the executable is started. Lazy resolution of GOT
 entries is intended to speed up program loading by deferring symbol
-resolution to the first time the function is called. The first entry
-in the PLT occupies two 16 byte entries:
+resolution to the first time the function is called.
+
+The first entry in the PLT occupies two 16 byte entries for the default PLT style:
 
 [,asm]
 ----
@@ -749,17 +763,43 @@ in the PLT occupies two 16 byte entries:
     jr     t3
 ----
 
-Subsequent function entry stubs in the PLT take up 16 bytes and load a
-function pointer from the GOT. On the first call to a function, the
-entry redirects to the first PLT entry which calls `_dl_runtime_resolve`
-and fills in the GOT entry for subsequent calls to the function:
+And occupies three 16 byte entries for the simple landing pad PLT style:
+[,asm]
+----
+1:  lpad 0
+    auipc  t2, %pcrel_hi(.got.plt)
+    sub    t1, t1, t3               # shifted .got.plt offset + hdr size + 12
+    l[w|d] t3, %pcrel_lo(1b)(t2)    # _dl_runtime_resolve
+    addi   t1, t1, -(hdr size + 12) # shifted .got.plt offset
+    addi   t0, t2, %pcrel_lo(1b)    # &.got.plt
+    srli   t1, t1, log2(16/PTRSIZE) # .got.plt offset
+    l[w|d] t0, PTRSIZE(t0)          # link map
+    jr     t3
+    nop
+    nop
+----
 
+Subsequent function entry stubs in the PLT take up 16 bytes.
+On the first call to a function, the entry redirects to the first PLT entry
+which calls `_dl_runtime_resolve` and fills in the GOT entry for subsequent
+calls to the function.
+
+The code sequences of the PLT entry for the default PLT style:
 [,asm]
 ----
 1:  auipc   t3, %pcrel_hi(function@.got.plt)
     l[w|d]  t3, %pcrel_lo(1b)(t3)
     jalr    t1, t3
     nop
+----
+
+The code sequences of the PLT entry for the the simple landing pad PLT style:
+[,asm]
+----
+1:  lpad 0
+    auipc   t3, %pcrel_hi(function@.got.plt)
+    l[w|d]  t3, %pcrel_lo(1b)(t3)
+    jalr    t1, t3
 ----
 
 ==== Procedure Calls
@@ -1207,11 +1247,16 @@ The defined processor-specific dynamic array tags are listed in <<rv-dyn-tag>>.
 | Name                | Value      | d_un  | Executable        | Shared Object
 
 | DT_RISCV_VARIANT_CC | 0x70000001 | d_val | Platform specific | Platform specific
+| DT_RISCV_SIMPLE_LP_PLT | 0x70000003 | d_val | Platform specific | Platform specific
 |===
 
 An object must have the dynamic tag `DT_RISCV_VARIANT_CC` if it has one or more
 `R_RISCV_JUMP_SLOT` relocations against symbols with the `STO_RISCV_VARIANT_CC`
 attribute.
+
+`DT_RISCV_SIMPLE_LP_PLT` indicate PLTs enabled landing pad with simple labeling
+scheme, an object must have the dynamic tag `DT_RISCV_SIMPLE_LP_PLT` if
+`GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_SIMPLE` has set in the output.
 
 `DT_INIT` and `DT_FINI` are not required to be supported and should be avoided
 in favour of `DT_PREINIT_ARRAY`, `DT_INIT_ARRAY` and `DT_FINI_ARRAY`.

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1516,6 +1516,8 @@ Description:: Additional information about the program property type.
 each bit indicating a feature that the object file is compatible with. The
 linker should perform a bitwise AND operation when merging different objects.
 
+The value of `GNU_PROPERTY_RISCV_FEATURE_1_AND` is defined in <<rv-prog-prop-type>>.
+
 [%autowidth]
 |===
 | Bit | Bit Name

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1247,16 +1247,11 @@ The defined processor-specific dynamic array tags are listed in <<rv-dyn-tag>>.
 | Name                | Value      | d_un  | Executable        | Shared Object
 
 | DT_RISCV_VARIANT_CC | 0x70000001 | d_val | Platform specific | Platform specific
-| DT_RISCV_SIMPLE_LP_PLT | 0x70000003 | d_val | Platform specific | Platform specific
 |===
 
 An object must have the dynamic tag `DT_RISCV_VARIANT_CC` if it has one or more
 `R_RISCV_JUMP_SLOT` relocations against symbols with the `STO_RISCV_VARIANT_CC`
 attribute.
-
-`DT_RISCV_SIMPLE_LP_PLT` indicate PLTs enabled landing pad with simple labeling
-scheme, an object must have the dynamic tag `DT_RISCV_SIMPLE_LP_PLT` if
-`GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_SIMPLE` has set in the output.
 
 `DT_INIT` and `DT_FINI` are not required to be supported and should be avoided
 in favour of `DT_PREINIT_ARRAY`, `DT_INIT_ARRAY` and `DT_FINI_ARRAY`.

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1512,9 +1512,9 @@ Description:: Additional information about the program property type.
 
 ==== GNU_PROPERTY_RISCV_FEATURE_1_AND
 
-`GNU_PROPERTY_RISCV_FEATURE_1_AND` describes a set of features, where each bit
-represents a different feature. The linker should perform a bitwise AND
-operation when merging different objects.
+`GNU_PROPERTY_RISCV_FEATURE_1_AND` describe a set of processor features with
+each bit indicating a feature that the object file is compatible with. The
+linker should perform a bitwise AND operation when merging different objects.
 
 [%autowidth]
 |===

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1445,6 +1445,43 @@ that a linker or runtime loader needs to check for compatibility.
 The linker should ignore and discard unknown bits in program properties, and
 issue warnings or errors.
 
+[[rv-prog-prop-type]]
+.RISC-V-specific program property types
+[cols="3,2,2,3"]
+[width=80%]
+|===
+| Name                              | Value      | Size    | Meaning
+
+| GNU_PROPERTY_RISCV_FEATURE_1_AND  | 0xc0000000 | 4-bytes | RISC-V processor-specific features used in program.
+|===
+
+==== GNU_PROPERTY_RISCV_FEATURE_1_AND
+
+`GNU_PROPERTY_RISCV_FEATURE_1_AND` describe a set of features, each bit describe
+a different features.
+
+[%autowidth]
+|===
+| Bit | Bit Name
+|   0 | GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_SIMPLE
+|   1 | GNU_PROPERTY_RISCV_FEATURE_1_CFI_SS
+|===
+
+`GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_SIMPLE` This bit indicate that all executable
+sections are built to be compatible with the landing pad mechanism provided by
+the `Zicfilp` extension. An executable or shared library with this bit set is
+required to generate PLTs with the landing pad (`lpad`) instruction, and all
+label are set to `1`.
+
+`GNU_PROPERTY_RISCV_FEATURE_1_CFI_SS`: This bit indicate that all executable
+sections are built to be compatible with the shadow stack mechanism provided by
+the `Zicfiss` extension. Loading an executable or shared library with this bit
+set requires the execution environment to provide either the `Zicfiss` extension
+or the `Zimop` extension. When the executable or shared library is compiled with
+compressed instructions then loading an executable with this bit set requires
+the execution environment to provide the `Zicfiss` extension or to provide both
+the `Zcmop` and `Zimop` extensions.
+
 === Mapping Symbol
 
 The section can have a mixture of code and data or code with different ISAs.

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -736,8 +736,8 @@ using all other PLT sytle.
 [cols="1,2"]
 [width=70%]
 |===
-| Default PLT                  | -
-| Simple landing pad PLT | Must use this PLT style when `GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_SIMPLE` is set.
+| Default PLT               | -
+| Unlabeled landing pad PLT | Must use this PLT style when `GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_UNLABELED` is set.
 |===
 
 The first entry of a shared object PLT is a special entry that calls
@@ -768,9 +768,9 @@ And occupies three 16 byte entries for the simple landing pad PLT style:
 ----
 1:  lpad 0
     auipc  t2, %pcrel_hi(.got.plt)
-    sub    t1, t1, t3               # shifted .got.plt offset + hdr size + 12
+    sub    t1, t1, t3               # shifted .got.plt offset + hdr size + 16
     l[w|d] t3, %pcrel_lo(1b)(t2)    # _dl_runtime_resolve
-    addi   t1, t1, -(hdr size + 12) # shifted .got.plt offset
+    addi   t1, t1, -(hdr size + 16) # shifted .got.plt offset
     addi   t0, t2, %pcrel_lo(1b)    # &.got.plt
     srli   t1, t1, log2(16/PTRSIZE) # .got.plt offset
     l[w|d] t0, PTRSIZE(t0)          # link map
@@ -1511,21 +1511,23 @@ Description:: Additional information about the program property type.
 
 ==== GNU_PROPERTY_RISCV_FEATURE_1_AND
 
-`GNU_PROPERTY_RISCV_FEATURE_1_AND` describe a set of features, each bit describe
-a different features.
+
+`GNU_PROPERTY_RISCV_FEATURE_1_AND` describes a set of features, where each bit
+represents a different feature. The linker should perform a bitwise AND
+operation when merging different objects.
 
 [%autowidth]
 |===
 | Bit | Bit Name
-|   0 | GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_SIMPLE
+|   0 | GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_UNLABELED
 |   1 | GNU_PROPERTY_RISCV_FEATURE_1_CFI_SS
 |===
 
-`GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_SIMPLE` This bit indicate that all executable
-sections are built to be compatible with the landing pad mechanism provided by
-the `Zicfilp` extension. An executable or shared library with this bit set is
-required to generate PLTs with the landing pad (`lpad`) instruction, and all
-label are set to `0`.
+`GNU_PROPERTY_RISCV_FEATURE_1_CFI_LP_UNLABELED` This bit indicate that all
+executable sections are built to be compatible with the landing pad mechanism
+provided by the `Zicfilp` extension. An executable or shared library with this
+bit set is required to generate PLTs with the landing pad (`lpad`) instruction,
+and all label are set to `0`.
 
 `GNU_PROPERTY_RISCV_FEATURE_1_CFI_SS`: This bit indicate that all executable
 sections are built to be compatible with the shadow stack mechanism provided by

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -729,7 +729,7 @@ GOT (Global Offset Table) and PLT (Procedure Linkage Table).
 
 RISC-V defines several PLT styles, which are used in different situations.
 The default PLT style should be used if the program does not meet the conditions
-for using all other PLT sytles.
+for using any of the other PLT sytles.
 
 [[plt-style]]
 .PLT styles


### PR DESCRIPTION
We introduce .note.gnu.property section to store infomations that linker or runtime system may use, and we define two bit for landing pad and shadow stack.

Those two bit will checked by loader - and use that info to enable the landing pad checking and/or shadow stack feature.