### PR TITLE
Relaxable TLSDESC only requires that R_RISCV_TLSDESC_HI20 to be paired with R_RISCV_RELAX

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1848,9 +1848,9 @@ Relaxation candidate (`tX` and `tY` can be any combination of two general purpos
 ----
 label:
 	auipc tX, <hi>      // R_RISCV_TLSDESC_HI20 (symbol), R_RISCV_RELAX
-	lw    tY, tX, <lo>  // R_RISCV_TLSDESC_LOAD_LO12 (label), R_RISCV_RELAX
-	addi  a0, tX, <lo>  // R_RISCV_TLSDESC_ADD_LO12 (label), R_RISCV_RELAX
-	jalr  t0, tY        // R_RISCV_TLSDESC_CALL (label), R_RISCV_RELAX
+	lw    tY, tX, <lo>  // R_RISCV_TLSDESC_LOAD_LO12 (label)
+	addi  a0, tX, <lo>  // R_RISCV_TLSDESC_ADD_LO12 (label)
+	jalr  t0, tY        // R_RISCV_TLSDESC_CALL (label)
 ----
 
 Relaxation result:
@@ -1889,9 +1889,9 @@ Relaxation candidate (`tX` and `tY` can be any combination of two general purpos
 ----
 label:
 	auipc tX, <hi>      // R_RISCV_TLSDESC_HI20 (symbol), R_RISCV_RELAX
-	lw    tY, tX, <lo>  // R_RISCV_TLSDESC_LOAD_LO12 (label), R_RISCV_RELAX
-	addi  a0, tX, <lo>  // R_RISCV_TLSDESC_ADD_LO12 (label), R_RISCV_RELAX
-	jalr  t0, tY        // R_RISCV_TLSDESC_CALL (label), R_RISCV_RELAX
+	lw    tY, tX, <lo>  // R_RISCV_TLSDESC_LOAD_LO12 (label)
+	addi  a0, tX, <lo>  // R_RISCV_TLSDESC_ADD_LO12 (label)
+	jalr  t0, tY        // R_RISCV_TLSDESC_CALL (label)
 ----
 
 Relaxation result (long form):


### PR DESCRIPTION
Requiring 4 R_RISCV_RELAX relocations impose a large size increase to the relocatable file. To mitigate this size increase, we can say that the whole TLSDESC code sequence is relaxable if the first instruction (R_RISCV_TLSDESC_HI20) is paired with R_RISCV_RELAX.

A statically linked executable typically has a simple relocation resolver that handles just RELATIVE/IFUNC. For a `-fpic -mtls-dialect=desc` relocatable file, the linker is required to perform TLS optimization to local-exec for a statically linked executable. Therefore, instruction rewriting is essentially inevitable if the relocation resolver is kept simple. Ths general-dynamic TLS model, without a defined optimization scheme, actually has the same issue.