### PR TITLE
Name mangling for standard vector calling convention

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -433,6 +433,10 @@ NOTE: `setjmp`/`longjmp` follow the standard calling convention, which clobbers
 all vector registers. Hence, the standard vector calling convention variant
 won't disrupt the `jmp_buf` ABI.
 
+NOTE: Functions that use the standard vector calling convention
+variant follow an additional name mangling rule for {Cpp}.
+For more details, see <<Name Mangling for Standard Calling Convention Variant>>.
+
 === ILP32E Calling Convention
 
 IMPORTANT: RV32E is not a ratified base ISA and so we cannot guarantee the

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -149,6 +149,34 @@ See the "Type encodings" section in _Itanium {Cpp} ABI_
 for more detail on how to mangle types. Note that `__bf16` is mangled in the
 same way as `std::bfloat16_t`.
 
+=== Name Mangling for Standard Calling Convention Variant
+
+Function use standard calling convention variant have to append extra ABI tag to
+the function name mangling, the rule are same as the "ABI tags" section in
+_Itanium {Cpp} ABI_.
+
+.ABI Tag name for calling convention variants
+[cols="5,2"]
+[width=80%]
+|===
+| Name                                       | ABI tag name
+
+| Standard vector calling convention variant | riscv_vector_cc
+|===
+
+
+For example:
+[,c]
+----
+    __attribute__((riscv_vector_cc)) void foo();
+----
+
+is mangled as
+[,c]
+----
+    _Z3fooB15riscv_vector_ccv
+----
+
 === Name Mangling for Vector Data Types, Vector Mask Types and Vector Tuple Types.
 
 The vector data types and vector mask types, as defined in the section


### PR DESCRIPTION
Add extra name mangling rule for standard vector calling convention on C++ ABI, fortunately the Itanium C++ ABI already defined mangling rule for ABI tag, so we just need to define the ABI tag name.

Example for the mangling rule:
```c
__attribute__((riscv_vector_cc)) void foo();
// _Z3fooB15riscv_vector_ccv with this mangling rule
// _Z3foov without this mangling rule
```