### PR TITLE
Revert "Add GP-relative relocations"

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -463,15 +463,7 @@ Description:: Additional information about the relocation
                                             <| S + A - P
 .2+| 45      .2+| RVC_JUMP      .2+| Static  | _CJ-Type_         .2+| 11-bit PC-relative jump offset
                                             <| S + A - P
-.2+| 46      .2+| *Reserved*    .2+| -       |                   .2+| Reserved for future standard use
-                                            <|
-.2+| 47      .2+| GPREL_LO12_I  .2+| Static  | _I-type_          .2+| Low 12 bits of a 32-bit GP-relative address, `%gprel_lo(symbol)`
-                                            <| S + A - GP
-.2+| 48      .2+| GPREL_LO12_S  .2+| Static  | _S-Type_          .2+| Low 12 bits of a 32-bit GP-relative address, `%gprel_lo(symbol)`
-                                            <| S + A - GP
-.2+| 49      .2+| GPREL_HI20    .2+| Static  | _U-Type_          .2+| High 20 bits of a 32-bit GP-relative address, `%gprel_hi(symbol)`
-                                            <| S + A - GP
-.2+| 50      .2+| *Reserved*                          .2+| -        |                  .2+| Reserved for future standard use
+.2+| 46-50   .2+| *Reserved*    .2+| -       |                   .2+| Reserved for future standard use
                                             <|
 .2+| 51      .2+| RELAX         .2+| Static  |                   .2+| Instruction can be relaxed, paired with a normal relocation at the same address
                                             <|


### PR DESCRIPTION
This reverts commit d49e48097bcad410e7e6d96ebf9d94d6d41dc9c0.

Both the ePIC and FDPIC ABIs are expected to define relocation types which can be used for both PC-relative and GP-relative data, and are expected to define relaxations to optimize access to both types of data. Explicit, compiler-generated relocations using GP are only useful in cases where an object is known at compile time to be local and present in the GP-relative segment.  The relaxations will result in GP-relative accesses, but the relocations involved will be linker internal and need not have allocated standard numbers.