### PR TITLE
Fix AsciiDoc syntax error

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -595,7 +595,7 @@ member. The size of any object is a multiple of its alignment.
 === Fixed-length vector
 
 Various compilers have support for fixed-length vector types, for example GCC
-and Clang both support declaring a type with `__attribute__((vector_size(N))`,
+and Clang both support declaring a type with `\\__attribute__\((vector_size(N))`,
 where N is a positive number larger than zero.
 
 The alignment requirement for the fixed length vector shall be equivalent to the


### PR DESCRIPTION
To prevent AsciiDoc formatting substitutions in cases like these, single and double backslashes suffice:
https://docs.asciidoctor.org/asciidoc/latest/subs/prevent/

A more powerful tool is the "passthrough":
https://docs.asciidoctor.org/asciidoc/latest/pass/
This is a heavier hammer than is needed here. I do see passthroughs used elsewhere in this document, in cases where backslashes would suffice. I despise AsciiDoc too much to write a longer PR descriptio