### PR TITLE
Fix rendering of vector type tables

### DIFF
--- a/gen_vector_type_infos.py
+++ b/gen_vector_type_infos.py
@@ -81,7 +81,7 @@ print (".Type sizes and alignments for vector data types")
 print ("[cols=\"4,3,>3,>2\"]")
 print ("[width=80%]")
 print ("|===")
-print("| Internal Name | Type | Description")
+print ("| Internal Name          | Type                 | Size (Bytes)  | Alignment (Bytes)")
 print("")
 
 for sew in SEW:
@@ -93,6 +93,8 @@ for sew in SEW:
             mname = "__rvv_" + typename
             size = sizestr(lmul)
             print ("| %-22s | %-20s | %-18s | %d" %(mname, typename, size, sew/8))
+print ("|===")
+print ("")
 
 print (".Type sizes and alignments for vector tuple types")
 print ("[cols=\"4,3,>3,>2\"]")
@@ -100,6 +102,7 @@ print ("[width=80%]")
 print ("|===")
 
 print ("| Internal Name          | Type                 | Size (Bytes)  | Alignment (Bytes)")
+print ("")
 for sew in SEW:
     for lmul in LMUL:
         for nf in NF:
@@ -110,3 +113,4 @@ for sew in SEW:
                 mname = "__rvv_" + typename
                 size = sizestr(lmul, nf)
                 print ("| %-22s | %-20s | %-18s | %d" %(mname, typename, size, sew/8))
+print ("|===")

--- a/vector_type_infos.adoc
+++ b/vector_type_infos.adoc
@@ -2,7 +2,7 @@
 [cols="4,3,>3,>2"]
 [width=80%]
 |===
-| Internal Name | Type | Description
+| Internal Name          | Type                 | Size (Bytes)  | Alignment (Bytes)
 
 | __rvv_vint8mf8_t       | vint8mf8_t           | (VLEN / 8) / 8     | 1
 | __rvv_vuint8mf8_t      | vuint8mf8_t          | (VLEN / 8) / 8     | 1
@@ -88,11 +88,14 @@
 | __rvv_vint64m8_t       | vint64m8_t           | (VLEN / 8) * 8     | 8
 | __rvv_vuint64m8_t      | vuint64m8_t          | (VLEN / 8) * 8     | 8
 | __rvv_vfloat64m8_t     | vfloat64m8_t         | (VLEN / 8) * 8     | 8
+|===
+
 .Type sizes and alignments for vector tuple types
 [cols="4,3,>3,>2"]
 [width=80%]
 |===
 | Internal Name          | Type                 | Size (Bytes)  | Alignment (Bytes)
+
 | __rvv_vint8mf8x2_t     | vint8mf8x2_t         | (VLEN / 8) / 4     | 1
 | __rvv_vuint8mf8x2_t    | vuint8mf8x2_t        | (VLEN / 8) / 4     | 1
 | __rvv_vfloat8mf8x2_t   | vfloat8mf8x2_t       | (VLEN / 8) / 4     | 1
@@ -477,3 +480,4 @@
 | __rvv_vint64m4x2_t     | vint64m4x2_t         | (VLEN / 8) * 8     | 8
 | __rvv_vuint64m4x2_t    | vuint64m4x2_t        | (VLEN / 8) * 8     | 8
 | __rvv_vfloat64m4x2_t   | vfloat64m4x2_t       | (VLEN / 8) * 8     | 8
+|===


### PR DESCRIPTION
Table 2 does not render for me in github.  Delimiting the end of the table resolves this.

Also add newline after Table 2 header row so that it appears in bold like in Table 1.