### PR TITLE
PIC medany: Fix parameters of load instruction

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -122,7 +122,7 @@ This model is similar to the medium any code model, but uses the
 
          # Calculate address of non-local symbol
 .Ltmp3:  auipc  a0, %got_pcrel_hi(symbol)
-         l[w|d] a0, a0, %pcrel_lo(.Ltmp3)
+         l[w|d] a0, %pcrel_lo(.Ltmp3)(a0)
 ----
 
 == Dynamic Linking


### PR DESCRIPTION
The explanation of the medium position independent code model
    includes the instruction `l[w|d] a0, a0, %pcrel_lo(.Ltmp3)`
    to calculate the address of a non-local symbol.
    That's not the correct RISC-V syntax for a load instruction.
    Let's fix that.