### PR TITLE
Specify the Name Mangling Rule for Vector Function Decorated with OpenMP

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -452,6 +452,10 @@ NOTE: `setjmp`/`longjmp` follow the standard calling convention, which clobbers
 all vector registers. Hence, the standard vector calling convention variant
 won't disrupt the `jmp_buf` ABI.
 
+NOTE: Vector functions corresponding to scalar functions which are decorated with
+the OpenMP `declare simd` pragma need to obey an additional name mangling rule.
+For more details, see <<Name Mangling for Vector Function>>.
+
 NOTE: Functions that use the standard vector calling convention
 variant follow an additional name mangling rule for {Cpp}.
 For more details, see <<Name Mangling for Standard Calling Convention Variant>>.

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -322,11 +322,66 @@ mangled-vector-name := "_ZGV" <isa> <mask> <len> <parameters> "_" <func-name>
 
 "v":: Vector parameter, default value for no linear or uniform clause.
 
+For example:
+
+[,c]
+----
+    #pragma omp declare simd notinbranch
+    extern int foo (int x) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // VLS Mode, VLEN=128
+    vint32m1_t _ZGVr1N4v_foo  (vint32m1_t x);  // LMUL=1
+    vint32m2_t _ZGVr2N8v_foo  (vint32m2_t x);  // LMUL=2
+    vint32m4_t _ZGVr4N16v_foo (vint32m4_t x);  // LMUL=4
+    vint32m8_t _ZGVr8N32v_foo (vint32m8_t x);  // LMUL=8
+
+    // VLA Mode
+    vint32m1_t _ZGVr1Nxv_foo  (vint32m1_t x);  // LMUL=1
+    vint32m2_t _ZGVr2Nxv_foo  (vint32m2_t x);  // LMUL=2
+    vint32m4_t _ZGVr4Nxv_foo  (vint32m4_t x);  // LMUL=4
+    vint32m8_t _ZGVr8Nxv_foo  (vint32m8_t x);  // LMUL=8
+----
+
 "l" | "l" <number>:: This parameter is specified by the linear clause with a
 compile-time constant, and its type must be either an integral type or a pointer
 type. `number` is the value of the compile-time constant step, or it is an empty
 string if the constant step is 1. Additionally, the base type of this parameter
 must be an integral type.
+
+NOTE: In `linear(i:s)`, if the type of `i` is integral type, the compile-time
+constant step is `s`, and if its type is pointer type, the compile-time constant
+step is `s * sizeof(*i)`.
+
+For example:
+
+[,c]
+----
+    #pragma omp declare simd notinbranch linear(i)
+    extern int foo (int i) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // VLS Mode, VLEN=128
+    vint32m1_t _ZGVr1N4l_foo  (int i);  // LMUL=1
+    vint32m2_t _ZGVr2N8l_foo  (int i);  // LMUL=2
+    vint32m4_t _ZGVr4N16l_foo (int i);  // LMUL=4
+    vint32m8_t _ZGVr8N32l_foo (int i);  // LMUL=8
+
+    // VLA Mode
+    vint32m1_t _ZGVr1Nxvl_foo (int i);  // LMUL=1
+    vint32m2_t _ZGVr2Nxvl_foo (int i);  // LMUL=2
+    vint32m4_t _ZGVr4Nxvl_foo (int i);  // LMUL=4
+    vint32m8_t _ZGVr8Nxvl_foo (int i);  // LMUL=8
+----
+
 
 "R" | "R" <number>:: This parameter is specified by the linear clause with a
 compile-time constant. It has a ref modifier and its type must be reference type.
@@ -334,17 +389,101 @@ compile-time constant. It has a ref modifier and its type must be reference type
 string if the constant step is 1. Additionally, the base type of this parameter
 must be an integral type.
 
+NOTE: In `linear(ref(i):s)`, the compile-time constant step is `s * sizeof(*i)`.
+
+For example:
+
+[,c]
+----
+    #pragma omp declare simd notinbranch linear(ref(i))
+    extern int foo (int &i) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // VLS Mode, VLEN=128
+    vint32m1_t _ZGVr1N4R4_foo  (int *i);  // LMUL=1
+    vint32m2_t _ZGVr2N8R4_foo  (int *i);  // LMUL=2
+    vint32m4_t _ZGVr4N16R4_foo (int *i);  // LMUL=4
+    vint32m8_t _ZGVr8N32R4_foo (int *i);  // LMUL=8
+
+    // VLA Mode
+    vint32m1_t _ZGVr1NxR4_foo  (int *i);  // LMUL=1
+    vint32m2_t _ZGVr2NxR4_foo  (int *i);  // LMUL=2
+    vint32m4_t _ZGVr4NxR4_foo  (int *i);  // LMUL=4
+    vint32m8_t _ZGVr8NxR4_foo  (int *i);  // LMUL=8
+----
+
+
 "L" | "L" <number>:: This parameter is specified by the linear clause with a
 compile-time constant. It has either a val modifier or no modifier and its type
 must be reference type. `number` is the value of the compile-time constant step,
 or it is an empty string if the constant step is 1. Additionally, the base type
 of this parameter must be an integral type.
 
+NOTE: In `linear(val(i):s)`, the compile-time constant step is `s`.
+
+For example:
+
+[,c]
+----
+    #pragma omp declare simd notinbranch linear(val(i))
+    extern int foo (int &i) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // VLS Mode, VLEN=128
+    vint32m1_t _ZGVr1N4L_foo  (vint32m1_t i);  // LMUL=1
+    vint32m2_t _ZGVr2N8L_foo  (vint32m2_t i);  // LMUL=2
+    vint32m4_t _ZGVr4N16L_foo (vint32m4_t i);  // LMUL=4
+    vint32m8_t _ZGVr8N32L_foo (vint32m8_t i);  // LMUL=8
+
+    // VLA Mode
+    vint32m1_t _ZGVr1NxL_foo  (vint32m1_t i);  // LMUL=1
+    vint32m2_t _ZGVr2NxL_foo  (vint32m1_t i);  // LMUL=2
+    vint32m4_t _ZGVr4NxL_foo  (vint32m1_t i);  // LMUL=4
+    vint32m8_t _ZGVr8NxL_foo  (vint32m1_t i);  // LMUL=8
+----
+
+
 "U" | "U" <number>:: This parameter is specified by the linear clause with a
 compile-time constant. It has a uval modifier and its type must be reference type.
 `number` is the value of the compile-time constant step, or it is an empty
 string if the constant step is 1. Additionally, the base type of this parameter
 must be an integral type.
+
+NOTE: In `linear(uval(i):s)`, the compile-time constant step is `s`.
+
+For example:
+
+[,c]
+----
+    #pragma omp declare simd notinbranch linear(uval(i))
+    extern int foo (int &i) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // VLS Mode, VLEN=128
+    vint32m1_t _ZGVr1N4U_foo  (int *i);  // LMUL=1
+    vint32m2_t _ZGVr2N8U_foo  (int *i);  // LMUL=2
+    vint32m4_t _ZGVr4N16U_foo (int *i);  // LMUL=4
+    vint32m8_t _ZGVr8N32U_foo (int *i);  // LMUL=8
+
+    // VLA Mode
+    vint32m1_t _ZGVr1NxU_foo  (int *i);  // LMUL=1
+    vint32m2_t _ZGVr2NxU_foo  (int *i);  // LMUL=2
+    vint32m4_t _ZGVr4NxU_foo  (int *i);  // LMUL=4
+    vint32m8_t _ZGVr8NxU_foo  (int *i);  // LMUL=8
+----
+
 
 "ls" <pos>:: This parameter is specified by the linear clause with a
 loop-independent, runtime-invariant step parameter specified in the uniform clause.
@@ -353,12 +492,63 @@ Its type must be either an integral type or a pointer type. `pos' is the positio
 Additionally, both the base type of this parameter and the step parameter must be
 integral types.
 
+For example:
+
+[,c]
+----
+    #pragma omp declare simd notinbranch linear(i:c) uniform(c)
+    extern int foo (int i, int c) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // VLS Mode, VLEN=128
+    vint32m1_t _ZGVr1N4ls1_foo  (int i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2N8ls1_foo  (int i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4N16ls1_foo (int i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8N32ls1_foo (int i, int c);  // LMUL=8
+
+    // VLA Mode
+    vint32m1_t _ZGVr1Nxls1_foo  (int i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2Nxls1_foo  (int i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4Nxls1_foo  (int i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8Nxls1_foo  (int i, int c);  // LMUL=8
+----
+
+
 "Rs" <pos>:: This parameter is specified by the linear clause with a
 loop-independent, runtime-invariant step parameter specified in the uniform clause.
 It has a ref modifier and its type must be reference type. `pos' is the position
 (starting from 0) of the step parameter in the function parameter list.
 Additionally, both the base type of this parameter and the step parameter must be
 integral types.
+
+For example:
+
+[,c]
+----
+    #pragma omp declare simd notinbranch linear(ref(i):c) uniform(c)
+    extern int foo (int &i, int c) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // VLS Mode, VLEN=128
+    vint32m1_t _ZGVr1N4Rs1_foo  (int *i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2N8Rs1_foo  (int *i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4N16Rs1_foo (int *i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8N32Rs1_foo (int *i, int c);  // LMUL=8
+
+    // VLA Mode
+    vint32m1_t _ZGVr1NxRs1_foo  (int *i);  // LMUL=1
+    vint32m2_t _ZGVr2NxRs1_foo  (int *i);  // LMUL=2
+    vint32m4_t _ZGVr4NxRs1_foo  (int *i);  // LMUL=4
+    vint32m8_t _ZGVr8NxRs1_foo  (int *i);  // LMUL=8
+----
 
 "Ls" <pos>:: This parameter is specified by the linear clause with a
 loop-independent, runtime-invariant step parameter specified in the uniform clause.
@@ -367,6 +557,32 @@ It has either a val modifier or no modifier and its type must be reference type.
 parameter list. Additionally, both the base type of this parameter and the step
 parameter must be integral types.
 
+For example:
+
+[,c]
+----
+    #pragma omp declare simd notinbranch linear(val(i):c) uniform(c)
+    extern int foo (int &i, int c) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // VLS Mode, VLEN=128
+    vint32m1_t _ZGVr1N4Ls1_foo  (vint32m1_t i);  // LMUL=1
+    vint32m2_t _ZGVr2N8Ls1_foo  (vint32m2_t i);  // LMUL=2
+    vint32m4_t _ZGVr4N16Ls1_foo (vint32m4_t i);  // LMUL=4
+    vint32m8_t _ZGVr8N32Ls1_foo (vint32m8_t i);  // LMUL=8
+
+    // VLA Mode
+    vint32m1_t _ZGVr1NxLs1_foo  (vint32m1_t i);  // LMUL=1
+    vint32m2_t _ZGVr2NxLs1_foo  (vint32m1_t i);  // LMUL=2
+    vint32m4_t _ZGVr4NxLs1_foo  (vint32m1_t i);  // LMUL=4
+    vint32m8_t _ZGVr8NxLs1_foo  (vint32m1_t i);  // LMUL=8
+----
+
+
 "Us" <pos>:: This parameter is specified by the linear clause with a
 loop-independent, runtime-invariant step parameter specified in the uniform clause.
 It has a uval modifier and its type must be reference type. `pos' is the position
@@ -374,7 +590,89 @@ It has a uval modifier and its type must be reference type. `pos' is the positio
 Additionally, both the base type of this parameter and the step parameter must be
 integral types.
 
+For example:
+
+[,c]
+----
+    #pragma omp declare simd notinbranch linear(uval(i)) uniform(c)
+    extern int foo (int &i, int c) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // VLS Mode, VLEN=128
+    vint32m1_t _ZGVr1N4Us1_foo  (int *i);  // LMUL=1
+    vint32m2_t _ZGVr2N8Us1_foo  (int *i);  // LMUL=2
+    vint32m4_t _ZGVr4N16Us1_foo (int *i);  // LMUL=4
+    vint32m8_t _ZGVr8N32Us1_foo (int *i);  // LMUL=8
+
+    // VLA Mode
+    vint32m1_t _ZGVr1NxUs1_foo  (int *i);  // LMUL=1
+    vint32m2_t _ZGVr2NxUs1_foo  (int *i);  // LMUL=2
+    vint32m4_t _ZGVr4NxUs1_foo  (int *i);  // LMUL=4
+    vint32m8_t _ZGVr8NxUs1_foo  (int *i);  // LMUL=8
+----
+
 "u":: Uniform parameter, specified by uniform clause.
+
+For example:
+
+[,c]
+----
+    #pragma omp declare simd notinbranch uniform(i)
+    extern int foo (int i) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // VLS Mode, VLEN=128
+    vint32m1_t _ZGVr1N4u_foo  (int i);  // LMUL=1
+    vint32m2_t _ZGVr2N8u_foo  (int i);  // LMUL=2
+    vint32m4_t _ZGVr4N16u_foo (int i);  // LMUL=4
+    vint32m8_t _ZGVr8N32u_foo (int i);  // LMUL=8
+
+    // VLA Mode
+    vint32m1_t _ZGVr1Nxu_foo  (int i);  // LMUL=1
+    vint32m2_t _ZGVr2Nxu_foo  (int i);  // LMUL=2
+    vint32m4_t _ZGVr4Nxu_foo  (int i);  // LMUL=4
+    vint32m8_t _ZGVr8Nxu_foo  (int i);  // LMUL=8
+----
+
+=== Masking Variants
+
+The inbranch clauses define whether a vector function should accept a masking
+parameter which need to be added to the vector function signature as the first
+parameter.
+
+For example:
+
+[,c]
+----
+    #pragma omp declare simd inbranch
+    extern int foo (int x) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // VLS Mode, VLEN=128
+    vint32m1_t _ZGVr1M4v_foo  (vbool32_t mask, vint32m1_t x);  // LMUL=1
+    vint32m2_t _ZGVr2M8v_foo  (vbool16_t mask, vint32m2_t x);  // LMUL=2
+    vint32m4_t _ZGVr4M16v_foo (vbool8_t  mask, vint32m4_t x);  // LMUL=4
+    vint32m8_t _ZGVr8M32v_foo (vbool4_t  mask, vint32m8_t x);  // LMUL=8
+
+    // VLA Mode
+    vint32m1_t _ZGVr1Mxv_foo  (vbool32_t mask, vint32m1_t x);  // LMUL=1
+    vint32m2_t _ZGVr2Mxv_foo  (vbool16_t mask, vint32m2_t x);  // LMUL=2
+    vint32m4_t _ZGVr4Mxv_foo  (vbool8_t  mask, vint32m4_t x);  // LMUL=4
+    vint32m8_t _ZGVr8Mxv_foo  (vbool4_t  mask, vint32m8_t x);  // LMUL=8
+----
+
 
 == ELF Object Files
 

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -276,7 +276,9 @@ Name mangling rule for vector functions.
 
 [source,abnf]
 ----
-mangled-vector-name := "_ZGV" <lmul> <mask> <len> <parameters> "_" <func-name>
+mangled-vector-name := "_ZGV" <isa> <mask> <len> <parameters> "_" <func-name>
+
+<isa> := "r" <lmul>
 
 <lmul> := "1" | "2" | "4" | "8" (LMUL in turn is 1, 2, 4, 8)
         | "h" | "q" | "e"       (LMUL in turn is 1/2, 1/4, 1/8)

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -318,6 +318,57 @@ mangled-vector-name := "_ZGV" <isa> <mask> <len> <parameters> "_" <func-name>
 <func-name> := the orignal name of the scalar function
 ----
 
+=== Description of the lmul token
+
+"lmul":: The LMUL field is set based on the maximum LMUL value among the types
+of the parameters and the return value.
+
+For example:
+
+[,c]
+----
+    #pragma omp declare simd notinbranch
+    extern double foo (float x) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // VLS Mode, VLEN=128
+    vfloat64m2_t _ZGVr2N4v_foo  (vfloat32m1_t x);  // LMUL=2
+    vfloat64m4_t _ZGVr4N8v_foo  (vfloat32m2_t x);  // LMUL=4
+    vfloat64m8_t _ZGVr8N16v_foo (vfloat32m4_t x);  // LMUL=8
+
+    // VLA Mode
+    vfloat64m2_t _ZGVr2Nxv_foo  (vfloat32m1_t x);  // LMUL=2
+    vfloat64m4_t _ZGVr4Nxv_foo  (vfloat32m2_t x);  // LMUL=4
+    vfloat64m8_t _ZGVr8Nxv_foo  (vfloat32m4_t x);  // LMUL=8
+----
+
+As another example,
+
+[,c]
+----
+    #pragma omp declare simd notinbranch
+    extern float foo (double x) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // VLS Mode, VLEN=128
+    vfloat32m1_t _ZGVr2N4v_foo  (vfloat64m2_t x);  // LMUL=2
+    vfloat32m2_t _ZGVr4N8v_foo  (vfloat64m4_t x);  // LMUL=4
+    vfloat32m4_t _ZGVr8N16v_foo (vfloat64m8_t x);  // LMUL=8
+
+    // VLA Mode
+    vfloat32m1_t _ZGVr2Nxv_foo  (vfloat64m2_t x);  // LMUL=2
+    vfloat32m2_t _ZGVr4Nxv_foo  (vfloat64m4_t x);  // LMUL=4
+    vfloat32m4_t _ZGVr8Nxv_foo  (vfloat64m8_t x);  // LMUL=8
+----
+
 === Description of the parameter_type token
 
 "v":: Vector parameter, default value for no linear or uniform clause.

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -264,6 +264,116 @@ type-name = identifier-nondigit *identifier-char
 identifier-nondigit = ALPHA / "_"
 identifier-char = identifier-nondigit / "_"
 ----
+
+== Name Mangling for Vector Function
+
+This section describes how to name vector functions corresponding to scalar
+functions which are decorated with `#pragma omp declare simd`. The order of the
+vector function parameters should be the same as that of the original scalar
+function.
+
+Name mangling rule for vector functions.
+
+[source,abnf]
+----
+mangled-vector-name := "_ZGV" <lmul> <mask> <len> <parameters> "_" <func-name>
+
+<lmul> := "1" | "2" | "4" | "8" (LMUL in turn is 1, 2, 4, 8)
+        | "h" | "q" | "e"       (LMUL in turn is 1/2, 1/4, 1/8)
+
+<mask> := "N"  (No mask, default for no inbranch clause)
+        | "M"  (Mask, for inbranch clause)
+
+<len> := SIMDLEN (VLS Mode, the number of elements processed at a time)
+       | "x"     (VLA Mode)
+
+<parameters> := <parameter> { <parameter> }
+
+<parameter> := <parameter_type> [ <alignment> ]
+
+<parameter_type> := "v"
+                  | "l" | "l" <number>
+                  | "R" | "R" <number>
+                  | "L" | "L" <number>
+                  | "U" | "U" <number>
+                  | "ls" <pos>
+                  | "Rs" <pos>
+                  | "Ls" <pos>
+                  | "Us" <pos>
+                  | "u"
+
+<number> := "n" <X>  // if linear step is negative
+          | <Y>
+
+<pos> := <X>
+
+<X> := integral number greater than or equal to 1
+
+<Y> := integral number greater than or equal to 2
+
+<alignment> := [ "a" <X> ]  // specified by aligned clause
+
+<func-name> := the orignal name of the scalar function
+----
+
+=== Description of the parameter_type token
+
+"v":: Vector parameter, default value for no linear or uniform clause.
+
+"l" | "l" <number>:: This parameter is specified by the linear clause with a
+compile-time constant, and its type must be either an integral type or a pointer
+type. `number` is the value of the compile-time constant step, or it is an empty
+string if the constant step is 1. Additionally, the base type of this parameter
+must be an integral type.
+
+"R" | "R" <number>:: This parameter is specified by the linear clause with a
+compile-time constant. It has a ref modifier and its type must be reference type.
+`number` is the value of the compile-time constant step, or it is an empty
+string if the constant step is 1. Additionally, the base type of this parameter
+must be an integral type.
+
+"L" | "L" <number>:: This parameter is specified by the linear clause with a
+compile-time constant. It has either a val modifier or no modifier and its type
+must be reference type. `number` is the value of the compile-time constant step,
+or it is an empty string if the constant step is 1. Additionally, the base type
+of this parameter must be an integral type.
+
+"U" | "U" <number>:: This parameter is specified by the linear clause with a
+compile-time constant. It has a uval modifier and its type must be reference type.
+`number` is the value of the compile-time constant step, or it is an empty
+string if the constant step is 1. Additionally, the base type of this parameter
+must be an integral type.
+
+"ls" <pos>:: This parameter is specified by the linear clause with a
+loop-independent, runtime-invariant step parameter specified in the uniform clause.
+Its type must be either an integral type or a pointer type. `pos' is the position
+(starting from 0) of the step parameter in the function parameter list.
+Additionally, both the base type of this parameter and the step parameter must be
+integral types.
+
+"Rs" <pos>:: This parameter is specified by the linear clause with a
+loop-independent, runtime-invariant step parameter specified in the uniform clause.
+It has a ref modifier and its type must be reference type. `pos' is the position
+(starting from 0) of the step parameter in the function parameter list.
+Additionally, both the base type of this parameter and the step parameter must be
+integral types.
+
+"Ls" <pos>:: This parameter is specified by the linear clause with a
+loop-independent, runtime-invariant step parameter specified in the uniform clause.
+It has either a val modifier or no modifier and its type must be reference type.
+`pos' is the position (starting from 0) of the step parameter in the function
+parameter list. Additionally, both the base type of this parameter and the step
+parameter must be integral types.
+
+"Us" <pos>:: This parameter is specified by the linear clause with a
+loop-independent, runtime-invariant step parameter specified in the uniform clause.
+It has a uval modifier and its type must be reference type. `pos' is the position
+(starting from 0) of the step parameter in the function parameter list.
+Additionally, both the base type of this parameter and the step parameter must be
+integral types.
+
+"u":: Uniform parameter, specified by uniform clause.
+
 == ELF Object Files
 
 The ELF object file format for RISC-V follows the

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -554,22 +554,19 @@ is mangled as
     // 's' equals 1, and 'number' equals 1.
 
     // VLS Mode, VLEN=128
-    vint32m1_t _ZGVr1N4L_foo  (vint32m1_t i);  // LMUL=1
-    vint32m2_t _ZGVr2N8L_foo  (vint32m2_t i);  // LMUL=2
-    vint32m4_t _ZGVr4N16L_foo (vint32m4_t i);  // LMUL=4
-    vint32m8_t _ZGVr8N32L_foo (vint32m8_t i);  // LMUL=8
+    vint32m1_t _ZGVr2N4L_foo  (vint64m2_t i);  // LMUL=2
+    vint32m2_t _ZGVr4N8L_foo  (vint64m4_t i);  // LMUL=4
+    vint32m4_t _ZGVr8N16L_foo (vint64m8_t i);  // LMUL=8
 
     // VLS Mode, VLEN=256
-    vint32m1_t _ZGVr1N8L_foo  (vint32m1_t i);  // LMUL=1
-    vint32m2_t _ZGVr2N16L_foo (vint32m2_t i);  // LMUL=2
-    vint32m4_t _ZGVr4N32L_foo (vint32m4_t i);  // LMUL=4
-    vint32m8_t _ZGVr8N64L_foo (vint32m8_t i);  // LMUL=8
+    vint32m1_t _ZGVr2N8L_foo  (vint64m2_t i);  // LMUL=2
+    vint32m2_t _ZGVr4N16L_foo (vint64m4_t i);  // LMUL=4
+    vint32m4_t _ZGVr8N32L_foo (vint64m8_t i);  // LMUL=8
 
     // VLA Mode
-    vint32m1_t _ZGVr1NxL_foo  (vint32m1_t i);  // LMUL=1
-    vint32m2_t _ZGVr2NxL_foo  (vint32m1_t i);  // LMUL=2
-    vint32m4_t _ZGVr4NxL_foo  (vint32m1_t i);  // LMUL=4
-    vint32m8_t _ZGVr8NxL_foo  (vint32m1_t i);  // LMUL=8
+    vint32m1_t _ZGVr2NxL_foo  (vint64m2_t i);  // LMUL=2
+    vint32m2_t _ZGVr4NxL_foo  (vint64m4_t i);  // LMUL=4
+    vint32m4_t _ZGVr8NxL_foo  (vint64m8_t i);  // LMUL=8
 ----
 
 
@@ -749,22 +746,19 @@ is mangled as
     // The step parameter is variable 'c', which is the parameter at index 1 in the function argument list, so 'pos' equal to 1.
 
     // VLS Mode, VLEN=128
-    vint32m1_t _ZGVr1N4Ls1u_foo  (vint32m1_t i, int c);  // LMUL=1
-    vint32m2_t _ZGVr2N8Ls1u_foo  (vint32m2_t i, int c);  // LMUL=2
-    vint32m4_t _ZGVr4N16Ls1u_foo (vint32m4_t i, int c);  // LMUL=4
-    vint32m8_t _ZGVr8N32Ls1u_foo (vint32m8_t i, int c);  // LMUL=8
+    vint32m1_t _ZGVr2N4Ls1u_foo  (vint64m2_t i, int c);  // LMUL=2
+    vint32m2_t _ZGVr4N8Ls1u_foo  (vint64m4_t i, int c);  // LMUL=4
+    vint32m4_t _ZGVr8N16Ls1u_foo (vint64m8_t i, int c);  // LMUL=8
 
     // VLS Mode, VLEN=256
-    vint32m1_t _ZGVr1N8Ls1u_foo  (vint32m1_t i, int c);  // LMUL=1
-    vint32m2_t _ZGVr2N16Ls1u_foo (vint32m2_t i, int c);  // LMUL=2
-    vint32m4_t _ZGVr4N32Ls1u_foo (vint32m4_t i, int c);  // LMUL=4
-    vint32m8_t _ZGVr8N64Ls1u_foo (vint32m8_t i, int c);  // LMUL=8
+    vint32m1_t _ZGVr2N8Ls1u_foo  (vint64m2_t i, int c);  // LMUL=2
+    vint32m2_t _ZGVr4N16Ls1u_foo (vint64m4_t i, int c);  // LMUL=4
+    vint32m4_t _ZGVr8N32Ls1u_foo (vint64m8_t i, int c);  // LMUL=8
 
     // VLA Mode
-    vint32m1_t _ZGVr1NxLs1u_foo  (vint32m1_t i, int c);  // LMUL=1
-    vint32m2_t _ZGVr2NxLs1u_foo  (vint32m1_t i, int c);  // LMUL=2
-    vint32m4_t _ZGVr4NxLs1u_foo  (vint32m1_t i, int c);  // LMUL=4
-    vint32m8_t _ZGVr8NxLs1u_foo  (vint32m1_t i, int c);  // LMUL=8
+    vint32m1_t _ZGVr2NxLs1u_foo  (vint64m2_t i, int c);  // LMUL=2
+    vint32m2_t _ZGVr4NxLs1u_foo  (vint64m4_t i, int c);  // LMUL=4
+    vint32m4_t _ZGVr8NxLs1u_foo  (vint64m8_t i, int c);  // LMUL=8
 ----
 
 

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -340,6 +340,11 @@ is mangled as
     vfloat64m4_t _ZGVr4N8v_foo  (vfloat32m2_t x);  // LMUL=4
     vfloat64m8_t _ZGVr8N16v_foo (vfloat32m4_t x);  // LMUL=8
 
+    // VLS Mode, VLEN=256
+    vfloat64m2_t _ZGVr2N8v_foo  (vfloat32m1_t x);  // LMUL=2
+    vfloat64m4_t _ZGVr4N16v_foo (vfloat32m2_t x);  // LMUL=4
+    vfloat64m8_t _ZGVr8N32v_foo (vfloat32m4_t x);  // LMUL=8
+
     // VLA Mode
     vfloat64m2_t _ZGVr2Nxv_foo  (vfloat32m1_t x);  // LMUL=2
     vfloat64m4_t _ZGVr4Nxv_foo  (vfloat32m2_t x);  // LMUL=4
@@ -362,6 +367,11 @@ is mangled as
     vfloat32m1_t _ZGVr2N4v_foo  (vfloat64m2_t x);  // LMUL=2
     vfloat32m2_t _ZGVr4N8v_foo  (vfloat64m4_t x);  // LMUL=4
     vfloat32m4_t _ZGVr8N16v_foo (vfloat64m8_t x);  // LMUL=8
+
+    // VLS Mode, VLEN=256
+    vfloat32m1_t _ZGVr2N8v_foo  (vfloat64m2_t x);  // LMUL=2
+    vfloat32m2_t _ZGVr4N16v_foo (vfloat64m4_t x);  // LMUL=4
+    vfloat32m4_t _ZGVr8N32v_foo (vfloat64m8_t x);  // LMUL=8
 
     // VLA Mode
     vfloat32m1_t _ZGVr2Nxv_foo  (vfloat64m2_t x);  // LMUL=2
@@ -390,6 +400,12 @@ is mangled as
     vint32m2_t _ZGVr2N8v_foo  (vint32m2_t x);  // LMUL=2
     vint32m4_t _ZGVr4N16v_foo (vint32m4_t x);  // LMUL=4
     vint32m8_t _ZGVr8N32v_foo (vint32m8_t x);  // LMUL=8
+
+    // VLS Mode, VLEN=256
+    vint32m1_t _ZGVr1N8v_foo  (vint32m1_t x);  // LMUL=1
+    vint32m2_t _ZGVr2N16v_foo (vint32m2_t x);  // LMUL=2
+    vint32m4_t _ZGVr4N32v_foo (vint32m4_t x);  // LMUL=4
+    vint32m8_t _ZGVr8N64v_foo (vint32m8_t x);  // LMUL=8
 
     // VLA Mode
     vint32m1_t _ZGVr1Nxv_foo  (vint32m1_t x);  // LMUL=1
@@ -420,17 +436,56 @@ is mangled as
 
 [,c]
 ----
+    // The type of `i` is integral type and 's' equals 1, so 'number' also equals 1.
+
     // VLS Mode, VLEN=128
     vint32m1_t _ZGVr1N4l_foo  (int i);  // LMUL=1
     vint32m2_t _ZGVr2N8l_foo  (int i);  // LMUL=2
     vint32m4_t _ZGVr4N16l_foo (int i);  // LMUL=4
     vint32m8_t _ZGVr8N32l_foo (int i);  // LMUL=8
 
+    // VLS Mode, VLEN=256
+    vint32m1_t _ZGVr1N8l_foo  (int i);  // LMUL=1
+    vint32m2_t _ZGVr2N16l_foo (int i);  // LMUL=2
+    vint32m4_t _ZGVr4N32l_foo (int i);  // LMUL=4
+    vint32m8_t _ZGVr8N64l_foo (int i);  // LMUL=8
+
     // VLA Mode
     vint32m1_t _ZGVr1Nxvl_foo (int i);  // LMUL=1
     vint32m2_t _ZGVr2Nxvl_foo (int i);  // LMUL=2
     vint32m4_t _ZGVr4Nxvl_foo (int i);  // LMUL=4
     vint32m8_t _ZGVr8Nxvl_foo (int i);  // LMUL=8
+----
+
+[,c]
+----
+    #pragma omp declare simd notinbranch linear(i)
+    extern int foo (int *i) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // The type of `i` is pointer type and 's' equals 1, so 'number' also equals 4 (i.e., 1 * sizeof(int *)).
+
+    // VLS Mode, VLEN=128
+    vint32m1_t _ZGVr1N4l4_foo  (int *i);  // LMUL=1
+    vint32m2_t _ZGVr2N8l4_foo  (int *i);  // LMUL=2
+    vint32m4_t _ZGVr4N16l4_foo (int *i);  // LMUL=4
+    vint32m8_t _ZGVr8N32l4_foo (int *i);  // LMUL=8
+
+    // VLS Mode, VLEN=256
+    vint32m1_t _ZGVr1N8l4_foo  (int *i);  // LMUL=1
+    vint32m2_t _ZGVr2N16l4_foo (int *i);  // LMUL=2
+    vint32m4_t _ZGVr4N32l4_foo (int *i);  // LMUL=4
+    vint32m8_t _ZGVr8N64l4_foo (int *i);  // LMUL=8
+
+    // VLA Mode
+    vint32m1_t _ZGVr1Nxvl4_foo (int *i);  // LMUL=1
+    vint32m2_t _ZGVr2Nxvl4_foo (int *i);  // LMUL=2
+    vint32m4_t _ZGVr4Nxvl4_foo (int *i);  // LMUL=4
+    vint32m8_t _ZGVr8Nxvl4_foo (int *i);  // LMUL=8
 ----
 
 
@@ -454,11 +509,19 @@ is mangled as
 
 [,c]
 ----
+    // 's' equals 1, and 'number' equals 4 (i.e., 1 * sizeof(int *)).
+
     // VLS Mode, VLEN=128
     vint32m1_t _ZGVr1N4R4_foo  (int *i);  // LMUL=1
     vint32m2_t _ZGVr2N8R4_foo  (int *i);  // LMUL=2
     vint32m4_t _ZGVr4N16R4_foo (int *i);  // LMUL=4
     vint32m8_t _ZGVr8N32R4_foo (int *i);  // LMUL=8
+
+    // VLS Mode, VLEN=256
+    vint32m1_t _ZGVr1N8R4_foo  (int *i);  // LMUL=1
+    vint32m2_t _ZGVr2N16R4_foo (int *i);  // LMUL=2
+    vint32m4_t _ZGVr4N32R4_foo (int *i);  // LMUL=4
+    vint32m8_t _ZGVr8N64R4_foo (int *i);  // LMUL=8
 
     // VLA Mode
     vint32m1_t _ZGVr1NxR4_foo  (int *i);  // LMUL=1
@@ -488,11 +551,19 @@ is mangled as
 
 [,c]
 ----
+    // 's' equals 1, and 'number' equals 1.
+
     // VLS Mode, VLEN=128
     vint32m1_t _ZGVr1N4L_foo  (vint32m1_t i);  // LMUL=1
     vint32m2_t _ZGVr2N8L_foo  (vint32m2_t i);  // LMUL=2
     vint32m4_t _ZGVr4N16L_foo (vint32m4_t i);  // LMUL=4
     vint32m8_t _ZGVr8N32L_foo (vint32m8_t i);  // LMUL=8
+
+    // VLS Mode, VLEN=256
+    vint32m1_t _ZGVr1N8L_foo  (vint32m1_t i);  // LMUL=1
+    vint32m2_t _ZGVr2N16L_foo (vint32m2_t i);  // LMUL=2
+    vint32m4_t _ZGVr4N32L_foo (vint32m4_t i);  // LMUL=4
+    vint32m8_t _ZGVr8N64L_foo (vint32m8_t i);  // LMUL=8
 
     // VLA Mode
     vint32m1_t _ZGVr1NxL_foo  (vint32m1_t i);  // LMUL=1
@@ -522,11 +593,19 @@ is mangled as
 
 [,c]
 ----
+    // 's' equals 1, and 'number' equals 1.
+
     // VLS Mode, VLEN=128
     vint32m1_t _ZGVr1N4U_foo  (int *i);  // LMUL=1
     vint32m2_t _ZGVr2N8U_foo  (int *i);  // LMUL=2
     vint32m4_t _ZGVr4N16U_foo (int *i);  // LMUL=4
     vint32m8_t _ZGVr8N32U_foo (int *i);  // LMUL=8
+
+    // VLS Mode, VLEN=256
+    vint32m1_t _ZGVr1N8U_foo  (int *i);  // LMUL=1
+    vint32m2_t _ZGVr2N16U_foo (int *i);  // LMUL=2
+    vint32m4_t _ZGVr4N32U_foo (int *i);  // LMUL=4
+    vint32m8_t _ZGVr8N64U_foo (int *i);  // LMUL=8
 
     // VLA Mode
     vint32m1_t _ZGVr1NxU_foo  (int *i);  // LMUL=1
@@ -555,17 +634,56 @@ is mangled as
 
 [,c]
 ----
+    // The step parameter is variable 'c', which is the parameter at index 1 in the function argument list, so 'pos' equal to 1.
+
     // VLS Mode, VLEN=128
-    vint32m1_t _ZGVr1N4ls1_foo  (int i, int c);  // LMUL=1
-    vint32m2_t _ZGVr2N8ls1_foo  (int i, int c);  // LMUL=2
-    vint32m4_t _ZGVr4N16ls1_foo (int i, int c);  // LMUL=4
-    vint32m8_t _ZGVr8N32ls1_foo (int i, int c);  // LMUL=8
+    vint32m1_t _ZGVr1N4ls1u_foo  (int i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2N8ls1u_foo  (int i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4N16ls1u_foo (int i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8N32ls1u_foo (int i, int c);  // LMUL=8
+
+    // VLS Mode, VLEN=256
+    vint32m1_t _ZGVr1N8ls1u_foo  (int i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2N16ls1u_foo (int i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4N32ls1u_foo (int i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8N64ls1u_foo (int i, int c);  // LMUL=8
 
     // VLA Mode
-    vint32m1_t _ZGVr1Nxls1_foo  (int i, int c);  // LMUL=1
-    vint32m2_t _ZGVr2Nxls1_foo  (int i, int c);  // LMUL=2
-    vint32m4_t _ZGVr4Nxls1_foo  (int i, int c);  // LMUL=4
-    vint32m8_t _ZGVr8Nxls1_foo  (int i, int c);  // LMUL=8
+    vint32m1_t _ZGVr1Nxls1u_foo  (int i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2Nxls1u_foo  (int i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4Nxls1u_foo  (int i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8Nxls1u_foo  (int i, int c);  // LMUL=8
+----
+
+[,c]
+----
+    #pragma omp declare simd notinbranch linear(i:c) uniform(c)
+    extern int foo (int *i, int c) __attribute__ ((__nothrow__, __leaf__, const));
+----
+
+is mangled as
+
+[,c]
+----
+    // The step parameter is variable 'c', which is the parameter at index 1 in the function argument list, so 'pos' equal to 1.
+
+    // VLS Mode, VLEN=128
+    vint32m1_t _ZGVr1N4ls1u_foo  (int *i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2N8ls1u_foo  (int *i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4N16ls1u_foo (int *i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8N32ls1u_foo (int *i, int c);  // LMUL=8
+
+    // VLS Mode, VLEN=256
+    vint32m1_t _ZGVr1N8ls1u_foo  (int *i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2N16ls1u_foo (int *i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4N32ls1u_foo (int *i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8N64ls1u_foo (int *i, int c);  // LMUL=8
+
+    // VLA Mode
+    vint32m1_t _ZGVr1Nxls1u_foo  (int *i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2Nxls1u_foo  (int *i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4Nxls1u_foo  (int *i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8Nxls1u_foo  (int *i, int c);  // LMUL=8
 ----
 
 
@@ -588,17 +706,25 @@ is mangled as
 
 [,c]
 ----
+    // The step parameter is variable 'c', which is the parameter at index 1 in the function argument list, so 'pos' equal to 1.
+
     // VLS Mode, VLEN=128
-    vint32m1_t _ZGVr1N4Rs1_foo  (int *i, int c);  // LMUL=1
-    vint32m2_t _ZGVr2N8Rs1_foo  (int *i, int c);  // LMUL=2
-    vint32m4_t _ZGVr4N16Rs1_foo (int *i, int c);  // LMUL=4
-    vint32m8_t _ZGVr8N32Rs1_foo (int *i, int c);  // LMUL=8
+    vint32m1_t _ZGVr1N4Rs1u_foo  (int *i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2N8Rs1u_foo  (int *i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4N16Rs1u_foo (int *i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8N32Rs1u_foo (int *i, int c);  // LMUL=8
+
+    // VLS Mode, VLEN=256
+    vint32m1_t _ZGVr1N8Rs1u_foo  (int *i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2N16Rs1u_foo (int *i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4N32Rs1u_foo (int *i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8N64Rs1u_foo (int *i, int c);  // LMUL=8
 
     // VLA Mode
-    vint32m1_t _ZGVr1NxRs1_foo  (int *i);  // LMUL=1
-    vint32m2_t _ZGVr2NxRs1_foo  (int *i);  // LMUL=2
-    vint32m4_t _ZGVr4NxRs1_foo  (int *i);  // LMUL=4
-    vint32m8_t _ZGVr8NxRs1_foo  (int *i);  // LMUL=8
+    vint32m1_t _ZGVr1NxRs1u_foo  (int *i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2NxRs1u_foo  (int *i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4NxRs1u_foo  (int *i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8NxRs1u_foo  (int *i, int c);  // LMUL=8
 ----
 
 "Ls" <pos>:: This parameter is specified by the linear clause with a
@@ -620,17 +746,25 @@ is mangled as
 
 [,c]
 ----
+    // The step parameter is variable 'c', which is the parameter at index 1 in the function argument list, so 'pos' equal to 1.
+
     // VLS Mode, VLEN=128
-    vint32m1_t _ZGVr1N4Ls1_foo  (vint32m1_t i);  // LMUL=1
-    vint32m2_t _ZGVr2N8Ls1_foo  (vint32m2_t i);  // LMUL=2
-    vint32m4_t _ZGVr4N16Ls1_foo (vint32m4_t i);  // LMUL=4
-    vint32m8_t _ZGVr8N32Ls1_foo (vint32m8_t i);  // LMUL=8
+    vint32m1_t _ZGVr1N4Ls1u_foo  (vint32m1_t i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2N8Ls1u_foo  (vint32m2_t i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4N16Ls1u_foo (vint32m4_t i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8N32Ls1u_foo (vint32m8_t i, int c);  // LMUL=8
+
+    // VLS Mode, VLEN=256
+    vint32m1_t _ZGVr1N8Ls1u_foo  (vint32m1_t i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2N16Ls1u_foo (vint32m2_t i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4N32Ls1u_foo (vint32m4_t i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8N64Ls1u_foo (vint32m8_t i, int c);  // LMUL=8
 
     // VLA Mode
-    vint32m1_t _ZGVr1NxLs1_foo  (vint32m1_t i);  // LMUL=1
-    vint32m2_t _ZGVr2NxLs1_foo  (vint32m1_t i);  // LMUL=2
-    vint32m4_t _ZGVr4NxLs1_foo  (vint32m1_t i);  // LMUL=4
-    vint32m8_t _ZGVr8NxLs1_foo  (vint32m1_t i);  // LMUL=8
+    vint32m1_t _ZGVr1NxLs1u_foo  (vint32m1_t i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2NxLs1u_foo  (vint32m1_t i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4NxLs1u_foo  (vint32m1_t i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8NxLs1u_foo  (vint32m1_t i, int c);  // LMUL=8
 ----
 
 
@@ -645,7 +779,7 @@ For example:
 
 [,c]
 ----
-    #pragma omp declare simd notinbranch linear(uval(i)) uniform(c)
+    #pragma omp declare simd notinbranch linear(uval(i):c) uniform(c)
     extern int foo (int &i, int c) __attribute__ ((__nothrow__, __leaf__, const));
 ----
 
@@ -653,17 +787,24 @@ is mangled as
 
 [,c]
 ----
-    // VLS Mode, VLEN=128
-    vint32m1_t _ZGVr1N4Us1_foo  (int *i);  // LMUL=1
-    vint32m2_t _ZGVr2N8Us1_foo  (int *i);  // LMUL=2
-    vint32m4_t _ZGVr4N16Us1_foo (int *i);  // LMUL=4
-    vint32m8_t _ZGVr8N32Us1_foo (int *i);  // LMUL=8
+    // The step parameter is variable 'c', which is the parameter at index 1 in the function argument list, so 'pos' equal to 1.
+
+    vint32m1_t _ZGVr1N4Us1u_foo  (int *i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2N8Us1u_foo  (int *i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4N16Us1u_foo (int *i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8N32Us1u_foo (int *i, int c);  // LMUL=8
+
+    // VLS Mode, VLEN=256
+    vint32m1_t _ZGVr1N8Us1u_foo  (int *i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2N16Us1u_foo (int *i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4N32Us1u_foo (int *i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8N64Us1u_foo (int *i, int c);  // LMUL=8
 
     // VLA Mode
-    vint32m1_t _ZGVr1NxUs1_foo  (int *i);  // LMUL=1
-    vint32m2_t _ZGVr2NxUs1_foo  (int *i);  // LMUL=2
-    vint32m4_t _ZGVr4NxUs1_foo  (int *i);  // LMUL=4
-    vint32m8_t _ZGVr8NxUs1_foo  (int *i);  // LMUL=8
+    vint32m1_t _ZGVr1NxUs1u_foo  (int *i, int c);  // LMUL=1
+    vint32m2_t _ZGVr2NxUs1u_foo  (int *i, int c);  // LMUL=2
+    vint32m4_t _ZGVr4NxUs1u_foo  (int *i, int c);  // LMUL=4
+    vint32m8_t _ZGVr8NxUs1u_foo  (int *i, int c);  // LMUL=8
 ----
 
 "u":: Uniform parameter, specified by uniform clause.
@@ -685,6 +826,12 @@ is mangled as
     vint32m2_t _ZGVr2N8u_foo  (int i);  // LMUL=2
     vint32m4_t _ZGVr4N16u_foo (int i);  // LMUL=4
     vint32m8_t _ZGVr8N32u_foo (int i);  // LMUL=8
+
+    // VLS Mode, VLEN=256
+    vint32m1_t _ZGVr1N8u_foo  (int i);  // LMUL=1
+    vint32m2_t _ZGVr2N16u_foo (int i);  // LMUL=2
+    vint32m4_t _ZGVr4N32u_foo (int i);  // LMUL=4
+    vint32m8_t _ZGVr8N64u_foo (int i);  // LMUL=8
 
     // VLA Mode
     vint32m1_t _ZGVr1Nxu_foo  (int i);  // LMUL=1
@@ -716,6 +863,12 @@ is mangled as
     vint32m2_t _ZGVr2M8v_foo  (vbool16_t mask, vint32m2_t x);  // LMUL=2
     vint32m4_t _ZGVr4M16v_foo (vbool8_t  mask, vint32m4_t x);  // LMUL=4
     vint32m8_t _ZGVr8M32v_foo (vbool4_t  mask, vint32m8_t x);  // LMUL=8
+
+    // VLS Mode, VLEN=256
+    vint32m1_t _ZGVr1M8v_foo  (vbool32_t mask, vint32m1_t x);  // LMUL=1
+    vint32m2_t _ZGVr2M16v_foo (vbool16_t mask, vint32m2_t x);  // LMUL=2
+    vint32m4_t _ZGVr4M32v_foo (vbool8_t  mask, vint32m4_t x);  // LMUL=4
+    vint32m8_t _ZGVr8M64v_foo (vbool4_t  mask, vint32m8_t x);  // LMUL=8
 
     // VLA Mode
     vint32m1_t _ZGVr1Mxv_foo  (vbool32_t mask, vint32m1_t x);  // LMUL=1


### PR DESCRIPTION
This pr is to introduce how to name the vector function associated to the scalar function decorated with an OpenMP `declare simd` directive.  It' s important because library vendor and compilers must follow this rule to interface with each other. For example, now risc-v doesn't support libmvec in glibc, if we want to support it, we need to know how to name the vectorized math functions.

I have referenced the aarch64 name manling rule` vfabia64` in <https://github.com/ARM-software/abi-aa/blob/main/vfabia64/vfabia64.rst#vector-function-signature>. The main difference is that the `lmul` in risc-v replace the `isa` in aarch64.