### PR TITLE
Two reals are assigned FP registers in memory order

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -318,7 +318,8 @@ a standalone floating-point real.
 
 A struct containing two floating-point reals is passed in two floating-point
 registers, if neither real is more than ABI_FLEN bits wide and at least two floating-point
-argument registers are available.  (The registers need not be an aligned pair.)
+argument registers are available.  (The registers need not be an aligned pair
+and are assigned to the two reals in memory order.)
 Otherwise, it is passed according to the integer calling convention.
 
 A complex floating-point number, or a struct containing just one complex


### PR DESCRIPTION
Clarification for languages that allow structs with arbitrary user-defined field offsets.

In Ada, GCC (gnat) passes this struct with a representation clause in two FP registers assigned in memory order (B in fa0, A in fa1) so I went with that.

```Ada
   type My_Struct is record
      A : Float;
      B : Float;
   end record;

   -- Reverse layout: B at 0, A at 4
   for My_Struct use record
      A at 4 range 0 .. 31;
      B at 0 range 0 .. 31;
   end record;
```