### PR TITLE
Clarify passing empty unions and arrays of empty structs/unions

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -283,7 +283,7 @@ floating-point registers than the ABI.
 For the purposes of this section, "struct" refers to a C struct with its
 hierarchy flattened, including any array fields.  That is, `struct { struct
 { float f[1]; } a[2]; }` and `struct { float f0; float f1; }` are
-treated the same.  Fields containing empty structs or unions are ignored while
+treated the same.  Fields containing empty structs are ignored while
 flattening, even in {Cpp}, unless they have nontrivial copy constructors or
 destructors.  Fields containing zero-length bit-fields or zero-length arrays are
 ignored while flattening.  Attributes such as `aligned` or `packed` do not
@@ -293,18 +293,20 @@ __attribute__((__packed__)) { int i; double d }+` are treated the same, as are
 `struct { float f; float g; }` and `+struct { float f; float g __attribute__
 ((aligned (8))); }+`.
 
-NOTE: One exceptional case for the flattening rule is an array of empty
-structs or unions; C treats it as an empty field, but {Cpp}
-treats it as a non-empty field since {Cpp} defines the size of an empty struct
-or union as 1. i.e. for `struct { struct {} e[1]; float f; }` as the first
-argument, C will treat it like `struct { float f; }` and pass `f` in `fa0` as
-described below, whereas {Cpp} will pass the pass the entire aggregate in `a0` 
-(XLEN = 64) or `a0` and `a1` (XLEN = 32), as described in the integer calling
-convention.
-Zero-length arrays of empty structs or union will be
-ignored for both C and {Cpp}. i.e. For `struct { struct {} e[0]; float f; };`,
-as the first argument, C and {Cpp} will treat it like `struct { float f; }`
-and pass `f` in `fa0` as described below.
+NOTE: One exceptional case for the flattening rule is an empty union, or an
+array or a union of empty structs or unions; C treats all of such fields in an
+aggregate as an empty field (no register is assigned but counts as one field),
+but {Cpp} treats them as a non-empty field since {Cpp} defines the size of an
+empty struct or union as 1. i.e. for `struct { struct {} e1[1], e2[1]; float f;
+ }` as the first argument, C will treat them like `struct { float f; }` and
+pass `f` in `fa0` as described below, whereas {Cpp} will pass the entire
+aggregate in `a0`(XLEN = 64) or `a0` and `a1` (XLEN = 32), as described in the
+integer calling convention; `struct { struct {} e[1]; float f0; float f1; }` is
+passed according to integer calling convention for both C and {Cpp}.
+All zero-length arrays of empty structs or unions in an aggregate will be
+treated as an empty field for both C and {Cpp}. i.e. for `struct { struct {}
+e1[0], e2[0]; float f; };`, as the first argument, C and {Cpp} will treat it
+like `struct { float f; }` and pass `f` in `fa0` as described below.
 
 A real floating-point argument is passed in a floating-point argument
 register if it is no more than ABI_FLEN bits wide and at least one floating-point
@@ -335,8 +337,8 @@ bits, the remaining bits are unspecified.
 If the struct is not passed in this manner, then it is passed according to the
 integer calling convention.
 
-Unions are never flattened and are always passed according to the integer
-calling convention.
+Unions of one or more non-empty fields are never flattened and are always
+passed according to the integer calling convention.
 
 Values are returned in the same manner as a first named argument of the same
 type would be passed.


### PR DESCRIPTION
The hardware floating-point calling convention was under-specified wrt empty unions and arrays of empty structs/unions, my proposal matches [GCC behavior](https://godbolt.org/z/jG1x9Mn5P). Key observations:
1. Empty unions are not ignored while flattening like empty structs but treated like zero-length arrays of empty structs/unions.
2. They seem to be counted as one empty field, i.e. `struct { struct {} e1[0], e2[0]; float f; }` is passed in `fa0` but `struct { struct {} e1[0], e2[0]; float f1, f2; }` is passed according to the integer calling convention in `a0` (because it has 3 fields?).
3. Same goes for unions and non-zero-length arrays of empty structs/unions in C.

```C
struct Se_1f {
    struct{} e1;
    float f;
};
struct Se_1f echo_Se_1f(int i, float f, struct Se_1f s) { return s; } // C and C++: FP call conv

struct Se_2f {
    struct{} e1;
    float f;
    float g;
};
struct Se_2f echo_Se_2f(int i, float f, struct Se_2f s) { return s; } // C and C++: FP call conv


struct Sme_1f {
    struct{} e1;
    struct {
        float f;
        struct{} e;
    } fe;
    struct{} e2;
};
struct Sme_1f echo_Sme_1f(int i, float f, struct Sme_1f s) { return s; } // C and C++: FP call conv

struct Sme_2f {
    struct{} e1;
    struct {
        float f;
        float g;
        struct{} e;
    } fe;
    struct{} e2;
};
struct Sme_2f echo_Sme_2f(int i, float f, struct Sme_2f s) { return s; } // C and C++: FP call conv


struct S0ae_1f {
    struct{} e1[0];
    float f;
};
struct S0ae_1f echo_S0ae_1f(int i, float f, struct S0ae_1f s) { return s; } // C and C++: FP call conv

struct S0ae_2f {
    struct{} e1[0];
    float f;
    float g;
};
struct S0ae_2f echo_S0ae_2f(int i, float f, struct S0ae_2f s) { return s; } // C and C++: int call conv


struct Sm0ae_1f {
    struct{} e1[0];
    struct {
        float f;
        struct{} e[0];
    } fe;
    struct{} e2[0];
};
struct Sm0ae_1f echo_Sm0ae_1f(int i, float f, struct Sm0ae_1f s) { return s; } // C and C++: FP call conv

struct Sm0ae_2f {
    struct{} e1[0];
    struct {
        float f;
        float g;
        struct{} e[0];
    } fe;
    struct{} e2[0];
};
struct Sm0ae_2f echo_Sm0ae_2f(int i, float f, struct Sm0ae_2f s) { return s; } // C and C++: int call conv


struct S1ae_1f {
    struct{} e1[1];
    float f;
};
struct S1ae_1f echo_S1ae_1f(int i, float f, struct S1ae_1f s) { return s; } // C: FP, C++ int call conv

struct S1ae_2f {
    struct{} e1[1];
    float f;
    float g;
};
struct S1ae_2f echo_S1ae_2f(int i, float f, struct S1ae_2f s) { return s; } // C and C++: int call conv


struct Sm1ae_1f {
    struct{} e1[1];
    struct {
        float f;
        struct{} e[1];
    } fe;
    struct{} e2[1];
};
struct Sm1ae_1f echo_Sm1ae_1f(int i, float f, struct Sm1ae_1f s) { return s; } // C: FP, C++ int call conv

struct Sm1ae_2f {
    struct{} e1[1];
    struct {
        float f;
        float g;
        struct{} e[1];
    } fe;
    struct{} e2[1];
};
struct Sm1ae_2f echo_Sm1ae_2f(int i, float f, struct Sm1ae_2f s) { return s; } // C and C++: int call conv


struct Seu_1f {
    union{} e1;
    float f;
};
struct Seu_1f echo_Seu_1f(int i, float f, struct Seu_1f s) { return s; } // C: FP, C++ int call conv

struct S2eu_2f {
    union{} e1;
    float f;
    float g;
};
struct S2eu_2f echo_S2eu_2f(int i, float f, struct S2eu_2f s) { return s; } // C and C++: int call conv


struct Smeu_1f {
    union{} e1;
    struct {
        float f;
        union{} e;
    } fe;
    union{} e2;
};
struct Smeu_1f echo_Smeu_1f(int i, float f, struct Smeu_1f s) { return s; } // C: FP, C++ int call conv

struct Smeu_2f {
    union{} e1;
    struct {
        float f;
        float g;
        union{} e;
    } fe;
    union{} e2;
};
struct Smeu_2f echo_Smeu_2f(int i, float f, struct Smeu_2f s) { return s; } // C and C++: int call conv


struct Su2e_1f {
    union{ struct{} e1, e2; } u;
    float f;
};
struct Su2e_1f echo_Su2e_1f(int i, float f, struct Su2e_1f s) { return s; } // C: FP, C++ int call conv

struct Su2e_2f {
    union{ struct{} e1, e2; } u;
    float f;
    float g;
};
struct Su2e_2f echo_Su2e_2f(int i, float f, struct Su2e_2f s) { return s; } // C and C++: int call conv


struct Smu2e_1f {
    union{ struct{} e1, e2; } u1;
    struct {
        float f;
        union{ struct{} e1, e2; } u;
    } ue;
    union{ struct{} e1, e2; } u2;
};
struct Smu2e_1f echo_Smu2e_1f(int i, float f, struct Smu2e_1f s) { return s; } // C: FP, C++ int call conv

struct Smu2e_2f {
    union{ struct{} e1, e2; } u1;
    struct {
        float f;
        float g;
        union{ struct{} e1, e2; } u;
    } ue;
    union{ struct{} e1, e2; } u2;
};
struct Smu2e_2f echo_Smu2e_2f(int i, float f, struct Smu2e_2f s) { return s; } // C and C++: int call conv
```