### PR TITLE
Document reserving standard encodings

### DIFF
--- a/introduction.adoc
+++ b/introduction.adoc
@@ -61,4 +61,10 @@ This specification uses the following terms and abbreviations:
 NOTE: ABI for big-endian is *NOT* included in this specification, we intend to
 define that in future version of this specification.
 
+Any encodings that are marked as reserved for a specific extension should be
+treated by standard tools identically to any other encodings reserved for
+future standard extensions. Such reservations are solely declarations of intent
+to reduce conflicts between in-flight extensions, and may be retracted at any
+point for any reason.
+
 :sectnums:

--- a/policy.md
+++ b/policy.md
@@ -51,6 +51,22 @@ Each type of modification has a different policy, based on the following rules:
     needed for reviews, but in case you want to reach out yourself you can find
     an incomplete list from [RISC-V International's wiki page].
 
+# Reserving Encodings
+
+- Relocations within the standard encoding space, or program header types etc.,
+  may be reserved for in-development standard extensions
+  - Such extensions must be under development by an existing TG and be well on
+    the way to ratification (such as, but not strictly required, be in the
+    stable state)
+  - A proof-of-concept toolchain ideally should exist
+  - A specification for the ABI additions ideally should exist
+  - The nature of extensions can vary, and so the policy here is intentionally
+    vague and incomplete; each request will be evaluated on a case-by-case
+    basis by the psABI community
+  - Encoding reservations are voluntary and non-binding; whilst the psABI
+    community intends to honour reasonable requests, it reserves the right to
+    stop reserving such encodings for any reason
+
 [@kito-cheng]: https://github.com/kito-cheng
 [@jrtc27]: https://github.com/jrtc27
 [RISC-V International's wiki page]: https://wiki.riscv.org/display/TECH/Toolchain+Projects


### PR DESCRIPTION
policy.md: Introduce a policy to allow reserving standard encodings

Most extensions don't require new relocations, but occasionally ones
arise that do (e.g. CFI and CHERI). Although the opcode encodings, and
even assembly mnemonics, are subject to change prior to ratification,
relocations (especially dynamic ones) can be much more far reaching and
require more than just recompiling with a new toolchain. It's therefore
helpful to be able to reserve encodings for the relocations the
extension will need before the ABI is fully specified and merged, and
before the ISA extension is ratified. This commit introduces an
intentionally-vague policy that starts to define how we should treat
such requests. This policy, like the rest of our policy, can evolve over
time as we gain experience from handling such requests.

introduction.adoc: Document how to treat encodings reserved for extensions

We want to make it clear that software should not start to assume that
an encoding reserved for a specific extension will always be for that
extension. For example, if that extension does not get ratified in a
reasonable amount of time, or if it needs to change its ABI such that an
encoding is no longer appropriate, such encodings will be reclaimed and
able to be reused for entirely different purposes.
