### PR TITLE
Account for flexible array members in the integer calling convention.

### DIFF
--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -209,7 +209,8 @@ type alignment and XLEN bits, but never more than the stack alignment.
 
 Aggregates larger than 2×XLEN bits are passed by reference and are replaced in
 the argument list with the address, as are {Cpp} aggregates with nontrivial copy
-constructors, destructors, or vtables.
+constructors, destructors, or vtables. Aggregates containing C99 flexible array
+members are similarly always passed by reference.
 
 Fixed-length vectors are treated as aggregates.
 


### PR DESCRIPTION
This appears to have been unspecified previously. Example miscompilation in LLVM reported here: https://github.com/llvm/llvm-project/issues/148536  