### PR TITLE
Add Tag_RISCV_mop_and_hint_encoding for instruction reinterpretation

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1272,6 +1272,7 @@ non-standard ABI extensions.
 | Tag_RISCV_priv_spec_revision        |       12 | uleb128        | *Deprecated*, indicates the revision version of the privileged specification.
 | Tag_RISCV_atomic_abi                |       14 | uleb128        | Indicates which version of the atomics ABI is being used.
 | Tag_RISCV_x3_reg_usage              |       16 | uleb128        | Indicates the usage definition of the X3 register.
+| Tag_RISCV_mop_and_hint_encoding     |       18 | uleb128        | Indicates the reinterpretation of MOP and hint instruction encodings.
 | Reserved for non-standard attribute | >= 32768 | -              | -
 |===
 
@@ -1436,6 +1437,34 @@ combined. However, an exception exists: the value `0` can merge with `1` or `2`
 value. After the merge, the resulting value will be the non-zero one.
 
 --
+
+===== Tag_RISCV_mop_and_hint_encoding, 18, uleb128=value
+
+Tag_RISCV_mop_and_hint_encoding indicates the reinterpretation of MOP (Maybe Operation) 
+and hint instruction encodings within this object. The value is a bitmap where each bit 
+indicates whether specific instruction encodings should be reinterpreted:
+
+[horizontal]
+Bit 0 (Zicfilp):: When set, `auipc x0, <value>` instructions are interpreted as `lpad <value>`.
+Bit 1 (Zicfiss):: When set, Zimop encoding space instructions are interpreted as Zicfiss instructions.
+Bit 2 (Zihintpause):: When set, `fence w,0` instructions are interpreted as `pause` hints.
+Bit 3 (Zihintntl):: When set, specific instruction encodings are interpreted as non-temporal locality hints.
+
+--
+
+Merge policy:::
+Values are merged using bitwise OR operation.
+
+NOTE: The bitwise OR merge policy may cause disassembler confusion when the same encoding 
+space is redefined by multiple bits. Toolchains may report warnings to alert users 
+when such conflicts occur.
+
+--
+
+NOTE: When specific bits are set, toolchains must disassemble instructions according to 
+the corresponding extensions regardless of whether these extensions are enabled. For example, 
+if bit 0 is set, `auipc x0, <value>` must be disassembled as `lpad <value>`; if bit 1 is 
+set, Zimop encodings must be disassembled as Zicfiss instructions.
 
 === Program Property
 

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1272,7 +1272,7 @@ non-standard ABI extensions.
 | Tag_RISCV_priv_spec_revision        |       12 | uleb128        | *Deprecated*, indicates the revision version of the privileged specification.
 | Tag_RISCV_atomic_abi                |       14 | uleb128        | Indicates which version of the atomics ABI is being used.
 | Tag_RISCV_x3_reg_usage              |       16 | uleb128        | Indicates the usage definition of the X3 register.
-| Tag_RISCV_mop_and_hint_encoding     |       18 | uleb128        | Indicates the reinterpretation of MOP and hint instruction encodings.
+| Tag_RISCV_mop_and_hint_encoding     |       18 | uleb128        | Indicates the reinterpretation of MOP and HINT instruction encodings.
 | Reserved for non-standard attribute | >= 32768 | -              | -
 |===
 
@@ -1440,13 +1440,16 @@ value. After the merge, the resulting value will be the non-zero one.
 
 ===== Tag_RISCV_mop_and_hint_encoding, 18, uleb128=value
 
+
 Tag_RISCV_mop_and_hint_encoding indicates the reinterpretation of MOP (Maybe Operation) 
-and hint instruction encodings within this object. The value is a bitmap where each bit 
-indicates whether specific instruction encodings should be reinterpreted:
+and HINT instruction encodings within this object. The value is a bitmap where each bit 
+indicates whether specific instruction encodings should be reinterpreted. For correct 
+decoding by disassemblers, hints are provided to describe how Maybe instructions and 
+similar encodings should be interpreted.
 
 [horizontal]
 Bit 0 (Zicfilp):: When set, `auipc x0, <value>` instructions are interpreted as `lpad <value>`.
-Bit 1 (Zicfiss):: When set, Zimop encoding space instructions are interpreted as Zicfiss instructions.
+Bit 1 (Zicfiss):: When set, Zimop/Zcmop encoding space instructions are interpreted as Zicfiss instructions.
 Bit 2 (Zihintpause):: When set, `fence w,0` instructions are interpreted as `pause` hints.
 Bit 3 (Zihintntl):: When set, specific instruction encodings are interpreted as non-temporal locality hints.
 
@@ -1464,7 +1467,7 @@ when such conflicts occur.
 NOTE: When specific bits are set, toolchains must disassemble instructions according to 
 the corresponding extensions regardless of whether these extensions are enabled. For example, 
 if bit 0 is set, `auipc x0, <value>` must be disassembled as `lpad <value>`; if bit 1 is 
-set, Zimop encodings must be disassembled as Zicfiss instructions.
+set, Zimop/Zcmop encodings must be disassembled as Zicfiss instructions.
 
 === Program Property
 


### PR DESCRIPTION
Various RISC-V extensions reuse existing instruction encoding spaces
for specialized behaviors. CFI extensions use NOP or MOP (Maybe Operation)
instructions to ensure correct program execution even when hardware 
doesn't implement CFI. Similarly, hint extensions redefine specific
encodings for performance optimization purposes.

However, this design conflicts with current toolchain conventions,
where X extension instructions are only usable when the X extension
is enabled: assemblers accept corresponding mnemonics and disassemblers
decode instructions only when the extension is active.

The affected use cases require different behavior:
- Zicfiss instructions should be available when Zimop extension is present
- Zicfilp instructions should be usable even without explicit enabling
  (since auipc is in baseline ISA)
- Hint extensions should reinterpret specific encodings regardless of
  extension enablement

Following conventional toolchain behavior would force compilers to
generate generic instructions ('mop', 'fence w,0', 'auipc x0, <value>')
instead of extension-specific mnemonics ('sspush/sspop', 'pause', 
'lpad <value>'), causing user confusion and reducing code clarity.

While this could be addressed at the ISA specification level, such
changes involve complex and time-consuming procedures. Therefore,
this psABI defines Tag_RISCV_mop_and_hint_encoding to provide toolchain
implementations with clear guidance.

This tag uses a bitmap format where each bit indicates whether specific
instruction encodings should be reinterpreted:
- Bit 0: auipc x0, <value> as lpad <value> (Zicfilp)
- Bit 1: Zimop encodings as Zicfiss instructions
- Bit 2: fence w,0 as pause hints (Zihintpause)
- Bit 3: specific encodings as non-temporal locality hints (Zihintntl)

The tag uses bitwise OR merge policy to allow combining multiple
reinterpretation requirements, with toolchain warnings recommended
when encoding space conflicts occur.