### PR TITLE
TLSDESC Relax Relocation Clarification

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -1920,7 +1920,10 @@ Relaxation result:
 
 Target Relocation:: R_RISCV_TLSDESC_HI20, R_RISCV_TLSDESC_LOAD_LO12, R_RISCV_TLSDESC_ADD_LO12, R_RISCV_TLSDESC_CALL
 
-Description:: This relaxation can relax a sequence loading the address of a thread-local symbol reference into a GOT load instruction.
+Description::
+
+This relaxation can relax a sequence loading the address of a thread-local symbol reference into a GOT load instruction.
+Unlike most other relaxations, this only requires a `R_RISCV_RELAX` relocation at the same location as the `R_RISCV_TLSDESC_HI20` relocation.
 
 Condition::
 - Linker output is an executable.
@@ -1939,9 +1942,9 @@ Relaxation candidate (`tX` and `tY` can be any combination of two general purpos
 ----
 label:
 	auipc tX, <hi>      // R_RISCV_TLSDESC_HI20 (symbol), R_RISCV_RELAX
-	lw    tY, tX, <lo>  // R_RISCV_TLSDESC_LOAD_LO12 (label), R_RISCV_RELAX
-	addi  a0, tX, <lo>  // R_RISCV_TLSDESC_ADD_LO12 (label), R_RISCV_RELAX
-	jalr  t0, tY        // R_RISCV_TLSDESC_CALL (label), R_RISCV_RELAX
+	lw    tY, tX, <lo>  // R_RISCV_TLSDESC_LOAD_LO12 (label)
+	addi  a0, tX, <lo>  // R_RISCV_TLSDESC_ADD_LO12 (label)
+	jalr  t0, tY        // R_RISCV_TLSDESC_CALL (label)
 ----
 
 Relaxation result:
@@ -1957,7 +1960,10 @@ Relaxation result:
 
 Target Relocation:: R_RISCV_TLSDESC_HI20, R_RISCV_TLSDESC_LOAD_LO12, R_RISCV_TLSDESC_ADD_LO12, R_RISCV_TLSDESC_CALL
 
-Description:: This relaxation can relax a sequence loading the address of a thread-local symbol reference into a thread-pointer-relative instruction sequence.
+Description::
+
+This relaxation can relax a sequence loading the address of a thread-local symbol reference into a thread-pointer-relative instruction sequence.
+Unlike most other relaxations, this only requires a `R_RISCV_RELAX` relocation at the same location as the `R_RISCV_TLSDESC_HI20` relocation.
 
 Condition::
 
@@ -1980,9 +1986,9 @@ Relaxation candidate (`tX` and `tY` can be any combination of two general purpos
 ----
 label:
 	auipc tX, <hi>      // R_RISCV_TLSDESC_HI20 (symbol), R_RISCV_RELAX
-	lw    tY, tX, <lo>  // R_RISCV_TLSDESC_LOAD_LO12 (label), R_RISCV_RELAX
-	addi  a0, tX, <lo>  // R_RISCV_TLSDESC_ADD_LO12 (label), R_RISCV_RELAX
-	jalr  t0, tY        // R_RISCV_TLSDESC_CALL (label), R_RISCV_RELAX
+	lw    tY, tX, <lo>  // R_RISCV_TLSDESC_LOAD_LO12 (label)
+	addi  a0, tX, <lo>  // R_RISCV_TLSDESC_ADD_LO12 (label)
+	jalr  t0, tY        // R_RISCV_TLSDESC_CALL (label)
 ----
 
 Relaxation result (long form):


### PR DESCRIPTION
Unlike all other relaxation sequences, TLSDESC relaxations only require a R_RISCV_RELAX on their first relocation. Clarify this fact in the text.