### PR TITLE
Note Vendor Relocation Scheme is for Static Relocations

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -584,8 +584,8 @@ purpose. These vendor-specific relocations must be preceded by a
 `R_RISCV_VENDOR` relocation against a vendor identifier symbol. The preceding
 `R_RISCV_VENDOR` relocation is used by the linker to choose the correct
 implementation for the associated nonstandard relocation. This scheme only
-specifies how to encode static vendor relocations; a future version of this
-specification may extend the scheme to support dynamic vendor relocations.
+specifies how to encode static nonstandard relocations; a future version of this
+specification may extend the scheme to support dynamic nonstandard relocations.
 
 The vendor identifier symbol should be a defined symbol and should set the type
 to `STT_NOTYPE`, binding to `STB_LOCAL`, and the size of symbol to zero.


### PR DESCRIPTION
Explicitly note that the vendor relocation scheme is only aimed at static relocations at the moment.

This resolves details such as `STB_LOCAL` symbols not usually appearing in dynamic symbol tables and `R_RISCV_VENDOR` being defined as a static relocation.

In future, we could extend this scheme to Dynamic Relocations, but that requires further consideration.

Co-authored-by: Jessica Clarke <jrtc27@jrtc27.com>