### PR TITLE
Reserve relocations for the RISC-V Y base ISA.

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -558,9 +558,11 @@ Description:: Additional information about the relocation
                                             <| S - P
 .2+| 65      .2+| TLSDESC_CALL      .2+| Static  |                   .2+| Annotate call to TLS descriptor resolver function, `%tlsdesc_call(address of %tlsdesc_hi)`, for relaxation purposes only
                                             <|
-.2+| 66-75   .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for Y base ISA
+.2+| 66      .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
                                             <|
-.2+| 76-190  .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
+.2+| 67-76   .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for Y base ISA
+                                            <|
+.2+| 77-190  .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
                                             <|
 .2+| 191     .2+| VENDOR        .2+| Static  |                   .2+| Paired with a vendor-specific relocation and must be placed immediately before it, indicates which vendor owns the relocation.
                                             <|


### PR DESCRIPTION
Per the defined criteria for reserving relocation numbers ahead of standardization, we would like to reserve 10 relocation numbers for the RISCV Y base ISA. Our current best estimate (based on existing CHERI ABI implementations and outstanding Y specification work items) is that the Y ISA will require 7 relocations. We prefer to round that up to 10 relocations for this reservation to reduce the risk of conflicts, with the intention of releasing any reserved relocation numbers that are unused once the Y base ABI is standardized.
