### PR TITLE
Add Relax Feature String for fine-grained linker relaxation control

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -528,7 +528,7 @@ Description:: Additional information about the relocation
                                             <| S + A - P
 .2+| 46-50   .2+| *Reserved*    .2+| -       |                   .2+| Reserved for future standard use
                                             <|
-.2+| 51      .2+| RELAX         .2+| Static  |                   .2+| Instruction can be relaxed, paired with a normal relocation at the same address
+.2+| 51      .2+| RELAX         .2+| Static  |                   .2+| Instruction can be relaxed, paired with a normal relocation at the same address. This relocation might point to an optional dummy symbol containing a Relax Feature String (see <<relax-feature-string>>), which specifies constraints on the relaxation process.
                                             <|
 .2+| 52      .2+| SUB6          .2+| Static  | _word6_           .2+| Local label subtraction
                                             <| V - S - A
@@ -2081,6 +2081,104 @@ instructions. It is recommended to initialize `jvt` CSR immediately after
     addi  a0, a0, %pcrel_lo(1b)
     csrw  jvt, a0
 ----
+
+[[relax-feature-string]]
+=== Relax Feature String
+
+A Relax Feature String is used to specify constraints on linker relaxation for
+individual instructions. When an `R_RISCV_RELAX` relocation references a symbol
+whose name starts with `$r`, the remainder of the symbol name is interpreted as
+a comma-separated list of features.
+
+The dummy symbol must have the following properties:
+
+- Name: starts with `$r` prefix
+- Binding: `STB_LOCAL`
+- Type: `STT_NOTYPE`
+- Size: 0
+
+Features in the string MUST be sorted in lexicographical (dictionary) order.
+If the features are not properly sorted, the linker behavior is undefined.
+
+==== Defined Features
+
+The following features are defined:
+
+[%autowidth]
+|===
+| Feature | Description
+
+| `norvc`
+| The instruction shall not be relaxed into a compressed instruction from the
+C or Zc* extensions (e.g., `c.j`, `c.jal`). This feature implies `nozcmt`,
+since Zcmt instructions (`cm.jt`, `cm.jalt`) are also compressed instructions.
+
+| `nozcmt`
+| The instruction shall not be relaxed into a table jump instruction from the
+Zcmt extension (e.g., `cm.jt`, `cm.jalt`).
+
+|===
+
+NOTE: Zcmt instructions are typically much slower than a regular `auipc` + `jalr`
+sequence because they require a table lookup before the actual jump. In
+performance-critical code regions, users may want to prevent instructions from
+being relaxed into Zcmt instructions by using the `nozcmt` feature.
+
+Multiple features can be specified in a single string, separated by commas.
+For example, `$rnorvc,nozcmt` prohibits both compressed instruction relaxation
+and table jump relaxation (though `$rnorvc` alone is sufficient since it
+implies `nozcmt`).
+
+The linker or assembler might simplify the feature string by removing redundant
+features (e.g., simplifying `$rnorvc,nozcmt` to `$rnorvc`).
+
+Unknown features should be ignored by the linker. Linkers may emit a warning
+message when encountering unknown features.
+
+==== Example
+
+[,asm]
+----
+    .option push
+    .option arch, rv32imafdc_zcmt
+    auipc ra, 0          # R_RISCV_CALL_PLT (symbol), R_RISCV_RELAX
+    jalr  ra, ra, 0      # Can be relaxed to jal, c.jal, or cm.jalt
+    .option pop
+
+    .option push
+    .option norvc
+    auipc ra, 0          # R_RISCV_CALL_PLT (symbol), R_RISCV_RELAX ($rnorvc)
+    jalr  ra, ra, 0      # Can only be relaxed to jal (norvc implies nozcmt)
+    .option pop
+
+    .option push
+    .option nozcmt
+    auipc ra, 0          # R_RISCV_CALL_PLT (symbol), R_RISCV_RELAX ($rnozcmt)
+    jalr  ra, ra, 0      # Can be relaxed to jal or c.jal, but NOT cm.jalt
+    .option pop
+----
+
+==== Use Case: LPAD Alignment
+
+When Zicfilp is enabled, LPAD instructions must be 4-byte aligned. For calls
+to `returns_twice` functions (e.g., `setjmp`), the following LPAD must remain
+aligned even after linker relaxation.
+
+[,asm]
+----
+    .p2align 2           # R_RISCV_ALIGN
+    .option push
+    .option norvc
+    call  setjmp         # R_RISCV_CALL_PLT (setjmp), R_RISCV_RELAX ($rnorvc)
+    lpad 0               # Must be 4-byte aligned
+    .option pop
+----
+
+Using `.option norvc` generates `R_RISCV_RELAX` with `$rnorvc`, which allows
+the call to be relaxed to `jal` (4-byte instruction) while preventing
+relaxation to 2-byte instructions like `c.jal` or `cm.jalt` that would
+misalign the following LPAD. This is more precise than using `.option exact`,
+which would completely disable relaxation.
 
 [bibliography]
 == References


### PR DESCRIPTION
This proposal serves as an alternative to PR #393, introducing Relax Feature String to specify constraints on linker relaxation for individual instructions.

When both `.option arch, +c` and `.option arch, -c` code regions exist in the same object file, the linker cannot properly handle this mixed situation because `EF_RISCV_RVC` is an object-level flag.

The Zcmt extension attempts to relax `call`/`tail`/`jal` instructions into `cm.jalt`/`cm.jt`. In baremetal toolchain multilib scenarios, using ISA strings leads to only two choices:

1. Add a Zcmt-specific multilib (increases toolchain release size, and the multilib is identical to non-Zcmt version except ISA string)
2. Violate the arch string semantics

When Zicfilp is enabled, LPAD instructions must be 4-byte aligned. Linker relaxation may convert call to `c.jal` or `cm.jalt`, causing LPAD misalignment. The current `.option exact` solution completely disables relaxation, which is overly conservative.

1. **Long strings**: ISA strings like RVA23 profile can be considerable
2. **Poor extensibility**: Cannot express "allow RVC but prohibit Zcmt"
3. **Zcmt semantic issues**: Cannot elegantly handle Zcmt opt-out
4. **Linker performance**: Complex ISA string parsing

Extend `R_RISCV_RELAX` to optionally reference a dummy symbol with prefix `$r` containing comma-separated feature flags.

- **Name**: starts with `$r` prefix (e.g., `$rnorvc`)
- **Binding**: `STB_LOCAL`
- **Type**: `STT_NOTYPE`
- **Size**: 0

Features MUST be sorted in lexicographical order. This simplifies linker parsing overhead.

| Feature | Description |
|---------|-------------|
| `norvc` | Prohibit relaxation into compressed instructions (C/Zc*). Implies `nozcmt` since `cm.jt`/`cm.jalt` are also compressed. | | `nozcmt` | Prohibit relaxation into Zcmt table jump instructions. Useful for performance-critical regions since Zcmt requires table lookup. |

Old linkers ignore the symbol referenced by `R_RISCV_RELAX`, so they use default relaxation behavior.