### PR TITLE
Add new relocation type for global array accesses with non-constant indices.

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -588,17 +588,17 @@ Description:: Additional information about the relocation
                                             <|
 .2+| 66      .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
                                             <|
-.2+| 67      .2+| REGREL_LO12_I .2+| Static  | _I-Type_          .2+| Low 12 bits of 32-bit Global Array Offset, `%regrel_lo(symbol)`
+.2+| 67-76   .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for Y base ISA
                                             <|
-.2+| 68      .2+| REGREL_LO12_S .2+| Static  | _S-Type_          .2+| Low 12 bits of 32-bit Global Array Offset, `%regrel_lo(symbol)`
+.2+| 77      .2+| REGREL_LO12_I .2+| Static  | _I-Type_          .2+| Low 12 bits of 32-bit Global Array Offset, `%regrel_lo(symbol)`
                                             <|
-.2+| 69      .2+| REGREL_ADD    .2+| Static  |                   .2+| Global Array usage, `%regrel_add(symbol)`
+.2+| 78      .2+| REGREL_LO12_S .2+| Static  | _S-Type_          .2+| Low 12 bits of 32-bit Global Array Offset, `%regrel_lo(symbol)`
                                             <|
-.2+| 70      .2+| REGREL_SHXADD .2+| Static  |                   .2+| Global Array usage, `%regrel_shxadd(symbol)`
+.2+| 79      .2+| REGREL_ADD    .2+| Static  |                   .2+| Global Array usage, `%regrel_add(symbol)`
                                             <|
-.2+| 71-76   .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for Y base ISA
+.2+| 80      .2+| REGREL_SHXADD .2+| Static  |                   .2+| Global Array usage, `%regrel_shxadd(symbol)`
                                             <|
-.2+| 77-190  .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
+.2+| 81-190  .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
                                             <|
 .2+| 191     .2+| VENDOR        .2+| Static  |                   .2+| Paired with a vendor-specific relocation and must be placed immediately before it, indicates which vendor owns the relocation.
                                             <|
@@ -1898,7 +1898,8 @@ Relaxation result:
   instruction sequence if possible.
 
   Condition:: Global-pointer relaxation requires that Tag_RISCV_x3_reg_usage
-  must be 0 or 1, and offset between global-pointer and symbol is within +-2KiB
+  must be 0 or 1, and offset between global-pointer and symbol is within +-2KiB.
+  `R_RISCV_REGREL_SHXADD` the Zba feature is required.
 
   Relaxation::
   - Instruction associated  with `R_RISCV_HI20` can be removed.
@@ -1910,7 +1911,7 @@ Relaxation result:
   Example::
 +
 --
-Relaxation candidate:
+Relaxation candidate 1:
 [,asm]
 ----
     lui tX, 0       # R_RISCV_HI20 (symbol), R_RISCV_RELAX
@@ -1921,7 +1922,22 @@ Relaxation result:
 [,asm]
 ----
     add tY, tY, gp
-    lw t1, <address-of-symbol>(tY)
+    lw t1, <gp-offset-for-symbol>(tY)
+----
++
+--
+Relaxation candidate 2: same as sh2add/sh3add
+[,asm]
+----
+    lui tX, 0          # R_RISCV_HI20 (symbol), R_RISCV_RELAX
+    sh1add tY, tY, tX  # R_RISCV_REGREL_SHXADD (symbol), R_RISCV_RELAX
+    lw t1, 0(tY)       # R_RISCV_REGREL_LO12_I (symbol), R_RISCV_RELAX
+----
+Relaxation result:
+[,asm]
+----
+    sh1add tY, tY, gp
+    lw t1, <gp-offset-for-symbol>(tY)
 ----
 --
 

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -588,7 +588,15 @@ Description:: Additional information about the relocation
                                             <|
 .2+| 66      .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
                                             <|
-.2+| 67-76   .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for Y base ISA
+.2+| 67      .2+| REGREL_LO12_I .2+| Static  | _I-Type_          .2+| Low 12 bits of 32-bit Global Array Offset, `%regrel_lo(symbol)`
+                                            <|
+.2+| 68      .2+| REGREL_LO12_S .2+| Static  | _S-Type_          .2+| Low 12 bits of 32-bit Global Array Offset, `%regrel_lo(symbol)`
+                                            <|
+.2+| 69      .2+| REGREL_ADD    .2+| Static  |                   .2+| Global Array usage, `%regrel_add(symbol)`
+                                            <|
+.2+| 70      .2+| REGREL_SHXADD .2+| Static  |                   .2+| Global Array usage, `%regrel_shxadd(symbol)`
+                                            <|
+.2+| 71-76   .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for Y base ISA
                                             <|
 .2+| 77-190  .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
                                             <|
@@ -1877,6 +1885,43 @@ Relaxation result:
 [,asm]
 ----
     lw t1, <address-of-symbol>(x0)
+----
+--
+
+==== Global Array Offset Relaxation
+
+  Target Relocation:: R_RISCV_HI20, R_RISCV_REGREL_LO12_I, R_RISCV_REGREL_LO12_S,
+  R_RISCV_REGREL_ADD, R_RISCV_REGREL_SHXADD
+
+  Description:: This relaxation type can relax a sequence of the load
+  address of a symbol or load/store with a symbol reference into shorter
+  instruction sequence if possible.
+
+  Condition:: Global-pointer relaxation requires that Tag_RISCV_x3_reg_usage
+  must be 0 or 1, and offset between global-pointer and symbol is within +-2KiB
+
+  Relaxation::
+  - Instruction associated  with `R_RISCV_HI20` can be removed.
+
+  - Instruction associated with `R_RISCV_REGREL_ADD` or `R_RISCV_REGREL_SHXADD`
+    can be replaced with a global-pointer-relative access instruction. Update the
+    `R_RISCV_REGREL_LO12_I` or `R_RISCV_REGREL_LO12_S` Symbol's Offset
+
+  Example::
++
+--
+Relaxation candidate:
+[,asm]
+----
+    lui tX, 0       # R_RISCV_HI20 (symbol), R_RISCV_RELAX
+    add tY, tY, tX  # R_RISCV_REGREL_ADD (symbol), R_RISCV_RELAX
+    lw t1, 0(tY)    # R_RISCV_REGREL_LO12_I (symbol), R_RISCV_RELAX
+----
+Relaxation result:
+[,asm]
+----
+    add tY, tY, gp
+    lw t1, <address-of-symbol>(tY)
 ----
 --
 

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -596,8 +596,6 @@ Description:: Additional information about the relocation
                                             <|
 .2+| 79      .2+| REGREL_ADD    .2+| Static  |                   .2+| Global Array usage, `%regrel_add(symbol)`
                                             <|
-.2+| 80      .2+| REGREL_SHXADD .2+| Static  |                   .2+| Global Array usage, `%regrel_shxadd(symbol)`
-                                            <|
 .2+| 81-190  .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
                                             <|
 .2+| 191     .2+| VENDOR        .2+| Static  |                   .2+| Paired with a vendor-specific relocation and must be placed immediately before it, indicates which vendor owns the relocation.
@@ -1891,7 +1889,7 @@ Relaxation result:
 ==== Global Array Offset Relaxation
 
   Target Relocation:: R_RISCV_HI20, R_RISCV_REGREL_LO12_I, R_RISCV_REGREL_LO12_S,
-  R_RISCV_REGREL_ADD, R_RISCV_REGREL_SHXADD
+  R_RISCV_REGREL_ADD
 
   Description:: This relaxation type can relax a sequence of the load
   address of a symbol or load/store with a symbol reference into shorter
@@ -1899,14 +1897,13 @@ Relaxation result:
 
   Condition:: Global-pointer relaxation requires that Tag_RISCV_x3_reg_usage
   must be 0 or 1, and offset between global-pointer and symbol is within +-2KiB.
-  `R_RISCV_REGREL_SHXADD` the Zba feature is required.
 
   Relaxation::
   - Instruction associated  with `R_RISCV_HI20` can be removed.
 
-  - Instruction associated with `R_RISCV_REGREL_ADD` or `R_RISCV_REGREL_SHXADD`
-    can be replaced with a global-pointer-relative access instruction. Update the
-    `R_RISCV_REGREL_LO12_I` or `R_RISCV_REGREL_LO12_S` Symbol's Offset
+  - Instruction associated with `R_RISCV_REGREL_ADD` can be replaced with a
+    global-pointer-relative access instruction. Update the `R_RISCV_REGREL_LO12_I`
+    or `R_RISCV_REGREL_LO12_S` Symbol's Offset
 
   Example::
 +
@@ -1930,7 +1927,7 @@ Relaxation candidate 2: same as sh2add/sh3add
 [,asm]
 ----
     lui tX, 0          # R_RISCV_HI20 (symbol), R_RISCV_RELAX
-    sh1add tY, tY, tX  # R_RISCV_REGREL_SHXADD (symbol), R_RISCV_RELAX
+    sh1add tY, tY, tX  # R_RISCV_REGREL_ADD (symbol), R_RISCV_RELAX
     lw t1, 0(tY)       # R_RISCV_REGREL_LO12_I (symbol), R_RISCV_RELAX
 ----
 Relaxation result:

--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -590,11 +590,11 @@ Description:: Additional information about the relocation
                                             <|
 .2+| 67-76   .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for Y base ISA
                                             <|
-.2+| 77      .2+| REGREL_LO12_I .2+| Static  | _I-Type_          .2+| Low 12 bits of 32-bit Global Array Offset, `%regrel_lo(symbol)`
+.2+| 77      .2+| R_RISCV_BASE_IDX_LO12_I .2+| Static  | _I-Type_          .2+| Low 12 bits of 32-bit Global Array Offset, `%base_idx_lo(symbol)`
                                             <|
-.2+| 78      .2+| REGREL_LO12_S .2+| Static  | _S-Type_          .2+| Low 12 bits of 32-bit Global Array Offset, `%regrel_lo(symbol)`
+.2+| 78      .2+| R_RISCV_BASE_IDX_LO12_S .2+| Static  | _S-Type_          .2+| Low 12 bits of 32-bit Global Array Offset, `%base_idx_lo(symbol)`
                                             <|
-.2+| 79      .2+| REGREL_ADD    .2+| Static  |                   .2+| Global Array usage, `%regrel_add(symbol)`
+.2+| 79      .2+| R_RISCV_BASE_IDX_ADD    .2+| Static  |                   .2+| Global Array usage, `%base_idx_add(symbol)`
                                             <|
 .2+| 81-190  .2+| *Reserved*                          .2+| -       |                   .2+| Reserved for future standard use
                                             <|
@@ -1888,8 +1888,8 @@ Relaxation result:
 
 ==== Global Array Offset Relaxation
 
-  Target Relocation:: R_RISCV_HI20, R_RISCV_REGREL_LO12_I, R_RISCV_REGREL_LO12_S,
-  R_RISCV_REGREL_ADD
+  Target Relocation:: R_RISCV_HI20, R_RISCV_BASE_IDX_LO12_I, R_RISCV_BASE_IDX_LO12_S,
+  R_RISCV_BASE_IDX_ADD, R_RISCV_PCREL_HI20
 
   Description:: This relaxation type can relax a sequence of the load
   address of a symbol or load/store with a symbol reference into shorter
@@ -1901,9 +1901,9 @@ Relaxation result:
   Relaxation::
   - Instruction associated  with `R_RISCV_HI20` can be removed.
 
-  - Instruction associated with `R_RISCV_REGREL_ADD` can be replaced with a
-    global-pointer-relative access instruction. Update the `R_RISCV_REGREL_LO12_I`
-    or `R_RISCV_REGREL_LO12_S` Symbol's Offset
+  - Instruction associated with `R_RISCV_BASE_IDX_ADD` can be replaced with a
+    global-pointer-relative access instruction. Update the `R_RISCV_BASE_IDX_LO12_I`
+    or `R_RISCV_BASE_IDX_LO12_S` Symbol's Offset
 
   Example::
 +
@@ -1912,8 +1912,8 @@ Relaxation candidate 1:
 [,asm]
 ----
     lui tX, 0       # R_RISCV_HI20 (symbol), R_RISCV_RELAX
-    add tY, tY, tX  # R_RISCV_REGREL_ADD (symbol), R_RISCV_RELAX
-    lw t1, 0(tY)    # R_RISCV_REGREL_LO12_I (symbol), R_RISCV_RELAX
+    add tY, tY, tX  # R_RISCV_BASE_IDX_ADD (symbol), R_RISCV_RELAX
+    lw t1, 0(tY)    # R_RISCV_BASE_IDX_LO12_I (symbol), R_RISCV_RELAX
 ----
 Relaxation result:
 [,asm]
@@ -1927,8 +1927,8 @@ Relaxation candidate 2: same as sh2add/sh3add
 [,asm]
 ----
     lui tX, 0          # R_RISCV_HI20 (symbol), R_RISCV_RELAX
-    sh1add tY, tY, tX  # R_RISCV_REGREL_ADD (symbol), R_RISCV_RELAX
-    lw t1, 0(tY)       # R_RISCV_REGREL_LO12_I (symbol), R_RISCV_RELAX
+    sh1add tY, tY, tX  # R_RISCV_BASE_IDX_ADD (symbol), R_RISCV_RELAX
+    lw t1, 0(tY)       # R_RISCV_BASE_IDX_LO12_I (symbol), R_RISCV_RELAX
 ----
 Relaxation result:
 [,asm]


### PR DESCRIPTION
Relocation Type Includes: R_RISCV_REGREL_ADD/R_RISCV_REGREL_LO12_I/R_RISCV_REGREL_LO12_S

The RISC-V architecture addresses non-constant subscript elements using lui + addi + add + ld/st. The low-address calculation process of addi instruction is offloaded th the ld/st, thereby eliminating low-address calculation and reducing addressing instructions.

The scenario is as follows: same as sh1add/sh2add/sh3add
```
lui     vr1, %hi(sym)
addi    vr1, vr1, %lo(sym)
add     vr2, vrx, vr1
lbu     vr3, off(vr2)
```
 After Compiler Transformation
```
lui     vr1, %hi(sym+off)
add     vr2, vrx, vr1, %regrel_add(sym+off)
lbu     vr3, %regrel_lo(sym+off)(vr2)
```
After Linker Relaxation:
```
add vr2, vrx, gp
lbu vr3, <gp-relative-offset>(vr2)
```
Need update the ld/st's offset and add/sh1add/sh2add/sh3add's src2 be replace by gp, so need add new relocation deal with this scenario.