### PR TITLE
Use pointer size in the frame layout instead of XLEN

### DIFF
--- a/introduction.adoc
+++ b/introduction.adoc
@@ -34,6 +34,7 @@ This specification uses the following terms and abbreviations:
 | NTBS              | Null-Terminated Byte String
 | XLEN              | The width of an integer register in bits
 | FLEN              | The width of a floating-point register in bits
+| PTRSZ             | The width of a pointer type in bits (`8*sizeof(void *)`)
 | Linker relaxation | A mechanism for optimizing programs at link-time, see <<Linker Relaxation>> for more detail.
 | RVWMO             | RISC-V Weak Memory Order, as defined in the RISC-V specification.
 |===

--- a/riscv-cc.adoc
+++ b/riscv-cc.adoc
@@ -45,18 +45,18 @@ it must reside in x8 (s0); the register remains callee-saved.
 
 Code that uses a frame pointer will construct a linked list of stack frames,
 where each frame links to its caller using a "frame record". A frame record
-consists of two XLEN values on the stack; the return address and the link to
+consists of two pointers on the stack; the return address and the link to
 the next frame record. The frame pointer register will point to the innermost
-frame, thereby starting the linked list. By convention, the lowest XLEN value
-shall point to the previous frame, while the next XLEN value shall be the
-return address. The end of the frame record chain is indicated by the address
-zero appearing as the next link in the chain.
+frame, thereby starting the linked list. By convention, the lowest pointer value
+shall point to the previous frame, while the next pointer value shall be the
+return address. The end of the frame record chain is indicated by a `NULL`
+pointer appearing as the next link in the chain.
 
 After the prologue, the frame pointer register will point to the Canonical
 Frame Address or CFA, which is the stack pointer value on entry to the current
 procedure. The previous frame pointer and return address pair will reside just
 prior to the current stack address held in `fp`. This puts the return address
-at `fp - XLEN/8`, and the previous frame pointer at `fp - 2 * XLEN/8`.
+at `fp - PTRSZ/8`, and the previous frame pointer at `fp - 2 * PTRSZ/8`.
 
 It is left to the platform to determine the level of conformance with this
 convention. A platform may choose:


### PR DESCRIPTION
This is motivated by RVY where the frame layout uses YLEN (2*XLEN) values to store the return address/frame pointer.

It is also technically a change for the RV64ILP32 ABI, but my understanding is that this change is actually a bug fix, since we are storing pointers.

Split out from https://github.com/riscv-non-isa/riscv-elf-psabi-doc/pull/499