### PR TITLE
[elf] Fix Section Heading

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -355,6 +355,8 @@ below.
 
 NOTE: RV64ILP32* ABIs are experimental.
 
+--
+
 Until such a time that the *Reserved* bits are allocated by future
 versions of this specification, they shall not be set by standard software.
 Non-standard extensions are free to use bits 24-31 for any purpose. This may
@@ -396,8 +398,6 @@ raise an error.
 NOTE: The static linker may ignore the compatibility checks if all fields in the
 `e_flags` are zero and all sections in the input file are non-executable
 sections.
-
---
 
 === String Tables
 


### PR DESCRIPTION
In asciidoc, you cannot put a `====` header (of any number of `=`) inside an open (`--`) block. If you do, the text is passed through directly.

I noticed there was a problem with the "Policy for Merge Objects with Different File Headers" header, which was inside an open block. The block is associated with the `e_flags` list, but the valid `e_flags` values are ended shortly before, and this is a new section describing how to merge not just `e_flags` but also the other top-level elf data.

The fix is to end the `--` block before the heading, so this heading shows up as a correctly numbered heading in the PDF and the HTML Document.

From my scans, this was the only place this has occurred.