### PR TITLE
Require a zero addend for R_RISCV_GOT_HI20

### DIFF
--- a/riscv-elf.adoc
+++ b/riscv-elf.adoc
@@ -502,8 +502,8 @@ Description:: Additional information about the relocation
                                             <| S + A - P
 .2+| 19      .2+| CALL_PLT      .2+| Static  | _U+I-Type_        .2+| 32-bit PC-relative function call, macros `call`, `tail` (PIC)
                                             <| S + A - P
-.2+| 20      .2+| GOT_HI20      .2+| Static  | _U-Type_          .2+| High 20 bits of 32-bit PC-relative GOT access, `%got_pcrel_hi(symbol)`
-                                            <| G + GOT + A - P
+.2+| 20      .2+| GOT_HI20      .2+| Static  | _U-Type_          .2+| High 20 bits of 32-bit PC-relative GOT access, `%got_pcrel_hi(symbol)`, the addend must be 0
+                                            <| G + GOT - P
 .2+| 21      .2+| TLS_GOT_HI20  .2+| Static  | _U-Type_          .2+| High 20 bits of 32-bit PC-relative TLS IE GOT access, macro `la.tls.ie`
                                             <|
 .2+| 22      .2+| TLS_GD_HI20   .2+| Static  | _U-Type_          .2+| High 20 bits of 32-bit PC-relative TLS GD GOT reference, macro `la.tls.gd`


### PR DESCRIPTION
The `R_RISCV_GOT_HI20` relocation was listed with a `G + GOT + A - P` calculation. A nonzero addend `A` makes the access resolve to the address of some arbitrary later GOT slot rather than the symbol's own GOT entry, which is not meaningful. Binutils has rejected a nonzero addend on this relocation as a dangerous relocation since 2021.

State that the addend must be 0 and drop the `+ A` term so the calculation reads `G + GOT - P`, matching the paired `R_RISCV_PCREL_LO12_I` relocation which already requires a zero addend.

Fix #188